### PR TITLE
Add VaxRecordKey class

### DIFF
--- a/src/main/java/seedu/vms/model/vaccination/VaxRecordKey.java
+++ b/src/main/java/seedu/vms/model/vaccination/VaxRecordKey.java
@@ -1,0 +1,58 @@
+package seedu.vms.model.vaccination;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+
+/**
+ * Similar to {@link VaxRecord} however, only containing the key to the
+ * {@link VaxType} instead of the instance.
+ */
+public class VaxRecordKey {
+    private final String vaxKey;
+    private final LocalDateTime timeTaken;
+
+
+    /**
+     * Constructs a {@code VaxRecordKey}.
+     *
+     * @param vaxKey - name of the vaccination.
+     * @param timeTaken - the time the vaccination was taken.
+     * @throws NullPointerException if any parameters are {@code null}.
+     */
+    public VaxRecordKey(String vaxKey, LocalDateTime timeTaken) {
+        this.vaxKey = Objects.requireNonNull(vaxKey);;
+        this.timeTaken = Objects.requireNonNull(timeTaken);
+    }
+
+
+    public String getVaxTypeKey() {
+        return vaxKey;
+    }
+
+
+    public LocalDateTime getTimeTaken() {
+        return timeTaken;
+    }
+
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof VaxRecordKey)) {
+            return false;
+        }
+
+        VaxRecordKey casted = (VaxRecordKey) other;
+        return vaxKey.equals(casted.vaxKey) && timeTaken.equals(casted.timeTaken);
+    }
+
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(vaxKey, timeTaken);
+    }
+}

--- a/src/test/java/seedu/vms/model/vaccination/VaxRecordKeyTest.java
+++ b/src/test/java/seedu/vms/model/vaccination/VaxRecordKeyTest.java
@@ -1,0 +1,67 @@
+package seedu.vms.model.vaccination;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+
+import org.junit.jupiter.api.Test;
+
+public class VaxRecordKeyTest {
+    private static final String SAMPLE_NAME = "UNCHI";
+    private static final LocalDateTime SAMPLE_TIME = LocalDateTime.now();
+    private static final VaxRecordKey SAMPLE_RECORD = new VaxRecordKey(SAMPLE_NAME, SAMPLE_TIME);
+
+
+    @Test
+    public void constructor_nullParam_exceptionThrown() {
+        assertThrows(NullPointerException.class,
+                () -> new VaxRecordKey(null, LocalDateTime.now()));
+        assertThrows(NullPointerException.class,
+                () -> new VaxRecordKey("abc", null));
+    }
+
+
+    @Test
+    public void getVaccination() {
+        assertEquals(SAMPLE_NAME, SAMPLE_RECORD.getVaxTypeKey());
+    }
+
+
+    @Test
+    public void getTimeTaken() {
+        assertEquals(SAMPLE_TIME, SAMPLE_RECORD.getTimeTaken());
+    }
+
+
+    @Test
+    public void equals() {
+        Object eqs = new VaxRecordKey(SAMPLE_NAME, SAMPLE_TIME);
+        Object diff1 = new VaxRecordKey(SAMPLE_NAME, LocalDateTime.MIN);
+        Object diff2 = new VaxRecordKey("BANANA", SAMPLE_TIME);
+        Object unrelated = Integer.valueOf(445);
+
+        assertTrue(SAMPLE_RECORD.equals(SAMPLE_RECORD));
+        assertTrue(SAMPLE_RECORD.equals(eqs));
+        assertFalse(SAMPLE_RECORD.equals(diff1));
+        assertFalse(SAMPLE_RECORD.equals(diff2));
+        assertFalse(SAMPLE_RECORD.equals(unrelated));
+    }
+
+
+    @Test
+    public void hashingTest() {
+        VaxRecordKey rec1 = SAMPLE_RECORD;
+        VaxRecordKey recEq = new VaxRecordKey(SAMPLE_NAME, SAMPLE_TIME);
+        VaxRecordKey recDiff = new VaxRecordKey("BANANA", SAMPLE_TIME);
+
+        HashSet<VaxRecordKey> recSet = new HashSet<>();
+        recSet.add(rec1);
+
+        assertTrue(recSet.contains(recEq));
+        assertFalse(recSet.contains(recDiff));
+    }
+}


### PR DESCRIPTION
Class to store the key pointer to `VaxType` instead of the actual instance for patient classes.

Resolves #90 