### PR TITLE
Add read and write functionalities for VaxType

### DIFF
--- a/src/main/java/seedu/vms/MainApp.java
+++ b/src/main/java/seedu/vms/MainApp.java
@@ -29,6 +29,8 @@ import seedu.vms.storage.JsonUserPrefsStorage;
 import seedu.vms.storage.Storage;
 import seedu.vms.storage.StorageManager;
 import seedu.vms.storage.UserPrefsStorage;
+import seedu.vms.storage.vaccination.JsonVaxTypeStorage;
+import seedu.vms.storage.vaccination.VaxTypeStorage;
 import seedu.vms.ui.Ui;
 import seedu.vms.ui.UiManager;
 
@@ -58,7 +60,8 @@ public class MainApp extends Application {
         UserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(config.getUserPrefsFilePath());
         UserPrefs userPrefs = initPrefs(userPrefsStorage);
         AddressBookStorage addressBookStorage = new JsonAddressBookStorage(userPrefs.getAddressBookFilePath());
-        storage = new StorageManager(addressBookStorage, userPrefsStorage);
+        VaxTypeStorage vaxTypeStorage = new JsonVaxTypeStorage();
+        storage = new StorageManager(addressBookStorage, vaxTypeStorage, userPrefsStorage);
 
         initLogging(config);
 
@@ -91,7 +94,15 @@ public class MainApp extends Application {
             initialData = new AddressBook();
         }
 
-        VaxTypeManager vaxTypeManager = storage.loadDefaultVaxTypes();
+        VaxTypeManager vaxTypeManager = new VaxTypeManager();
+        try {
+            vaxTypeManager = storage.loadUserVaxTypes();
+        } catch (IOException ioEx) {
+            logger.warning("Unable to load vaccination types, default will be loaded, problem: " + ioEx.getMessage());
+            vaxTypeManager = storage.loadDefaultVaxTypes();
+        } catch (RuntimeException rte) {
+            // not suppose to happen but initialize as empty
+        }
 
         return new ModelManager(initialData, vaxTypeManager, userPrefs);
     }

--- a/src/main/java/seedu/vms/commons/util/FileUtil.java
+++ b/src/main/java/seedu/vms/commons/util/FileUtil.java
@@ -1,8 +1,10 @@
 package seedu.vms.commons.util;
 
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -107,6 +109,17 @@ public class FileUtil {
      * @throws FileNotFoundException if the file cannot be found.
      */
     public static BufferedReader getFileReader(String pathString) throws FileNotFoundException {
-        return new BufferedReader(new FileReader(Paths.get(pathString).toFile()));
+        return new BufferedReader(new FileReader(Paths.get(pathString).toFile()), BUFFER_SIZE);
+    }
+
+
+    /**
+     * Returns the buffered writer to the specified file path.
+     *
+     * @throws IOException if an I/O exception occurs
+     *      (see {@link #FileWriter(java.io.File)}).
+     */
+    public static BufferedWriter getFileWriter(String pathString) throws IOException {
+        return new BufferedWriter(new FileWriter(Paths.get(pathString).toFile()), BUFFER_SIZE);
     }
 }

--- a/src/main/java/seedu/vms/commons/util/FileUtil.java
+++ b/src/main/java/seedu/vms/commons/util/FileUtil.java
@@ -50,6 +50,15 @@ public class FileUtil {
     }
 
     /**
+     * See {@link #createIfMissing(Path)}.
+     *
+     * @param pathString - the path to the file to create.
+     */
+    public static void createIfMissing(String pathString) throws IOException {
+        createIfMissing(Paths.get(pathString));
+    }
+
+    /**
      * Creates a file if it does not exist along with its missing parent directories.
      */
     public static void createFile(Path file) throws IOException {

--- a/src/main/java/seedu/vms/commons/util/JsonUtil.java
+++ b/src/main/java/seedu/vms/commons/util/JsonUtil.java
@@ -3,6 +3,7 @@ package seedu.vms.commons.util;
 import static java.util.Objects.requireNonNull;
 
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -112,6 +113,21 @@ public class JsonUtil {
                 throws IOException {
         try (BufferedReader reader = FileUtil.getFileReader(pathString)) {
             return objectMapper.readValue(reader, valueType);
+        }
+    }
+
+
+    /**
+     * Serializes the given object instance to the specified file.
+     *
+     * @param pathString - path of the file to serialize to.
+     * @param instance - the object instance to serialize.
+     * @throws IOException if an I/O error occurs.
+     */
+    public static void serializeToFile(String pathString, Object instance) throws IOException {
+        try (BufferedWriter writer = FileUtil.getFileWriter(pathString)) {
+            objectMapper.writerWithDefaultPrettyPrinter()
+                    .writeValue(writer, instance);
         }
     }
 

--- a/src/main/java/seedu/vms/logic/LogicManager.java
+++ b/src/main/java/seedu/vms/logic/LogicManager.java
@@ -53,6 +53,12 @@ public class LogicManager implements Logic {
             throw new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe);
         }
 
+        try {
+            storage.saveVaxTypes(model.getVaxTypeManager());
+        } catch (IOException ioe) {
+            throw new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe);
+        }
+
         return commandResult;
     }
 

--- a/src/main/java/seedu/vms/model/Model.java
+++ b/src/main/java/seedu/vms/model/Model.java
@@ -8,6 +8,7 @@ import seedu.vms.commons.core.GuiSettings;
 import seedu.vms.model.patient.Patient;
 import seedu.vms.model.patient.ReadOnlyAddressBook;
 import seedu.vms.model.vaccination.VaxType;
+import seedu.vms.model.vaccination.VaxTypeManager;
 
 /**
  * The API of the Model component.
@@ -90,4 +91,7 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPatientList(Predicate<Patient> predicate);
+
+    /** Returns the {@code VaxTypeManager} the model is using. */
+    VaxTypeManager getVaxTypeManager();
 }

--- a/src/main/java/seedu/vms/model/ModelManager.java
+++ b/src/main/java/seedu/vms/model/ModelManager.java
@@ -149,6 +149,11 @@ public class ModelManager implements Model {
         return vaxTypeManager.asUnmodifiableObservableMap();
     }
 
+    @Override
+    public VaxTypeManager getVaxTypeManager() {
+        return vaxTypeManager;
+    }
+
     //=========== Misc methods ================================================================================
 
     @Override

--- a/src/main/java/seedu/vms/model/vaccination/Requirement.java
+++ b/src/main/java/seedu/vms/model/vaccination/Requirement.java
@@ -42,6 +42,11 @@ public class Requirement {
     }
 
 
+    public RequirementType getReqType() {
+        return reqType;
+    }
+
+
     public HashSet<String> getReqSet() {
         return new HashSet<>(reqSet);
     }

--- a/src/main/java/seedu/vms/model/vaccination/VaxType.java
+++ b/src/main/java/seedu/vms/model/vaccination/VaxType.java
@@ -79,4 +79,23 @@ public class VaxType {
     public String toString() {
         return name;
     }
+
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof VaxType)) {
+            return false;
+        }
+
+        VaxType casted = (VaxType) other;
+        return name.equals(casted.name) && groups.equals(casted.groups)
+                && minAge == casted.minAge && maxAge == casted.maxAge
+                && minSpacing == casted.minSpacing
+                && allergyReqs.equals(casted.allergyReqs)
+                && historyReqs.equals(casted.historyReqs);
+    }
 }

--- a/src/main/java/seedu/vms/model/vaccination/VaxType.java
+++ b/src/main/java/seedu/vms/model/vaccination/VaxType.java
@@ -2,6 +2,7 @@ package seedu.vms.model.vaccination;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 
 
 /**
@@ -97,5 +98,11 @@ public class VaxType {
                 && minSpacing == casted.minSpacing
                 && allergyReqs.equals(casted.allergyReqs)
                 && historyReqs.equals(casted.historyReqs);
+    }
+
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, groups, minAge, maxAge, minSpacing, allergyReqs, historyReqs);
     }
 }

--- a/src/main/java/seedu/vms/storage/Storage.java
+++ b/src/main/java/seedu/vms/storage/Storage.java
@@ -8,12 +8,12 @@ import seedu.vms.commons.exceptions.DataConversionException;
 import seedu.vms.model.ReadOnlyUserPrefs;
 import seedu.vms.model.UserPrefs;
 import seedu.vms.model.patient.ReadOnlyAddressBook;
-import seedu.vms.model.vaccination.VaxTypeManager;
+import seedu.vms.storage.vaccination.VaxTypeStorage;
 
 /**
  * API of the Storage component
  */
-public interface Storage extends AddressBookStorage, UserPrefsStorage {
+public interface Storage extends AddressBookStorage, UserPrefsStorage, VaxTypeStorage {
 
     @Override
     Optional<UserPrefs> readUserPrefs() throws DataConversionException, IOException;
@@ -29,8 +29,5 @@ public interface Storage extends AddressBookStorage, UserPrefsStorage {
 
     @Override
     void saveAddressBook(ReadOnlyAddressBook addressBook) throws IOException;
-
-
-    VaxTypeManager loadDefaultVaxTypes();
 
 }

--- a/src/main/java/seedu/vms/storage/StorageManager.java
+++ b/src/main/java/seedu/vms/storage/StorageManager.java
@@ -11,7 +11,7 @@ import seedu.vms.model.ReadOnlyUserPrefs;
 import seedu.vms.model.UserPrefs;
 import seedu.vms.model.patient.ReadOnlyAddressBook;
 import seedu.vms.model.vaccination.VaxTypeManager;
-import seedu.vms.storage.vaccination.VaxTypeLoader;
+import seedu.vms.storage.vaccination.VaxTypeStorage;
 
 /**
  * Manages storage of AddressBook data in local storage.
@@ -20,13 +20,18 @@ public class StorageManager implements Storage {
 
     private static final Logger logger = LogsCenter.getLogger(StorageManager.class);
     private AddressBookStorage addressBookStorage;
+    private VaxTypeStorage vaxTypeStorage;
     private UserPrefsStorage userPrefsStorage;
 
     /**
      * Creates a {@code StorageManager} with the given {@code AddressBookStorage} and {@code UserPrefStorage}.
      */
-    public StorageManager(AddressBookStorage addressBookStorage, UserPrefsStorage userPrefsStorage) {
+    public StorageManager(
+                AddressBookStorage addressBookStorage,
+                VaxTypeStorage vaxTypeStorage,
+                UserPrefsStorage userPrefsStorage) {
         this.addressBookStorage = addressBookStorage;
+        this.vaxTypeStorage = vaxTypeStorage;
         this.userPrefsStorage = userPrefsStorage;
     }
 
@@ -80,15 +85,14 @@ public class StorageManager implements Storage {
     // ================ Vax Type methods ==============================
 
     @Override
-    public VaxTypeManager loadDefaultVaxTypes() {
+    public VaxTypeManager loadDefaultVaxTypes() throws RuntimeException {
         logger.fine("Attempting to load default vaccination types");
-        try {
-            return VaxTypeLoader.load();
-        } catch (Throwable ex) {
-            // should never happen but present just to be safe
-            logger.warning("Unable to load defaults");
-            return new VaxTypeManager();
-        }
+        return vaxTypeStorage.loadDefaultVaxTypes();
+    }
+
+    @Override
+    public VaxTypeManager loadUserVaxTypes() throws IOException {
+        return vaxTypeStorage.loadUserVaxTypes();
     }
 
 }

--- a/src/main/java/seedu/vms/storage/StorageManager.java
+++ b/src/main/java/seedu/vms/storage/StorageManager.java
@@ -95,4 +95,9 @@ public class StorageManager implements Storage {
         return vaxTypeStorage.loadUserVaxTypes();
     }
 
+    @Override
+    public void saveVaxTypes(VaxTypeManager manager) throws IOException {
+        vaxTypeStorage.saveVaxTypes(manager);
+    }
+
 }

--- a/src/main/java/seedu/vms/storage/vaccination/JsonAdaptedVaxRequirement.java
+++ b/src/main/java/seedu/vms/storage/vaccination/JsonAdaptedVaxRequirement.java
@@ -27,6 +27,15 @@ public class JsonAdaptedVaxRequirement {
 
 
     /**
+     * Converts the specified {@code Requirement} to a
+     * {@code JsonAdaptedVaxRequirement}.
+     */
+    public static JsonAdaptedVaxRequirement fromModelType(Requirement req) {
+        return new JsonAdaptedVaxRequirement(req.getReqType(), List.copyOf(req.getReqSet()));
+    }
+
+
+    /**
      * Converts this JSON friendly version to an {@link Requirement}
      * instance.
      *

--- a/src/main/java/seedu/vms/storage/vaccination/JsonAdaptedVaxType.java
+++ b/src/main/java/seedu/vms/storage/vaccination/JsonAdaptedVaxType.java
@@ -3,6 +3,7 @@ package seedu.vms.storage.vaccination;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -44,6 +45,30 @@ public class JsonAdaptedVaxType {
         this.minSpacing = minSpacing;
         this.allergyReqs = allergyReqs;
         this.historyReqs = historyReqs;
+    }
+
+
+    /**
+     * Converts the specified {@code VaxType} to a
+     * {@code JsonAdaptedVaxType}.
+     */
+    public static JsonAdaptedVaxType fromModelType(VaxType vaxType) {
+        String name = vaxType.getName();
+        List<String> groups = List.copyOf(vaxType.getGroups());
+        Integer minAge = vaxType.getMinAge();
+        Integer maxAge = vaxType.getMaxAge();
+        Integer minSpacing = vaxType.getMinSpacing();
+        List<JsonAdaptedVaxRequirement> allergyReqs = convertToAdaptedReq(vaxType.getAllergyReqs());
+        List<JsonAdaptedVaxRequirement> historyReqs = convertToAdaptedReq(vaxType.getHistoryReqs());
+
+        return new JsonAdaptedVaxType(name, groups, minAge, maxAge, minSpacing, allergyReqs, historyReqs);
+    }
+
+
+    private static List<JsonAdaptedVaxRequirement> convertToAdaptedReq(List<Requirement> reqs) {
+        return reqs.stream()
+                .map(req -> JsonAdaptedVaxRequirement.fromModelType(req))
+                .collect(Collectors.toList());
     }
 
 

--- a/src/main/java/seedu/vms/storage/vaccination/JsonVaxTypeStorage.java
+++ b/src/main/java/seedu/vms/storage/vaccination/JsonVaxTypeStorage.java
@@ -32,4 +32,10 @@ public class JsonVaxTypeStorage implements VaxTypeStorage {
             throw new RuntimeException("Unable to load defaults", ex);
         }
     }
+
+
+    @Override
+    public void saveVaxTypes(VaxTypeManager manager) throws IOException {
+        VaxTypeLoader.fromModelType(manager).write(USER_FILE_PATH);
+    }
 }

--- a/src/main/java/seedu/vms/storage/vaccination/JsonVaxTypeStorage.java
+++ b/src/main/java/seedu/vms/storage/vaccination/JsonVaxTypeStorage.java
@@ -6,7 +6,10 @@ import seedu.vms.commons.exceptions.IllegalValueException;
 import seedu.vms.model.vaccination.VaxTypeManager;
 
 
-
+/**
+ * An {@link VaxTypeStorage} to handle read and write operations from and to
+ * JSON files containing {@link VaxTypeManager} data.
+ */
 public class JsonVaxTypeStorage implements VaxTypeStorage {
     public static final String USER_FILE_PATH = "data/vaxtype.json";
 

--- a/src/main/java/seedu/vms/storage/vaccination/JsonVaxTypeStorage.java
+++ b/src/main/java/seedu/vms/storage/vaccination/JsonVaxTypeStorage.java
@@ -1,0 +1,32 @@
+package seedu.vms.storage.vaccination;
+
+import java.io.IOException;
+
+import seedu.vms.commons.exceptions.IllegalValueException;
+import seedu.vms.model.vaccination.VaxTypeManager;
+
+
+
+public class JsonVaxTypeStorage implements VaxTypeStorage {
+    public static final String USER_FILE_PATH = "data/vaxtype.json";
+
+
+    @Override
+    public VaxTypeManager loadUserVaxTypes() throws IOException {
+        try {
+            return VaxTypeLoader.load(USER_FILE_PATH);
+        } catch (IllegalValueException illValEx) {
+            throw new IOException(illValEx.getMessage());
+        }
+    }
+
+
+    @Override
+    public VaxTypeManager loadDefaultVaxTypes() throws RuntimeException {
+        try {
+            return VaxTypeLoader.load();
+        } catch (Throwable ex) {
+            throw new RuntimeException("Unable to load defaults", ex);
+        }
+    }
+}

--- a/src/main/java/seedu/vms/storage/vaccination/JsonVaxTypeStorage.java
+++ b/src/main/java/seedu/vms/storage/vaccination/JsonVaxTypeStorage.java
@@ -3,6 +3,7 @@ package seedu.vms.storage.vaccination;
 import java.io.IOException;
 
 import seedu.vms.commons.exceptions.IllegalValueException;
+import seedu.vms.commons.util.FileUtil;
 import seedu.vms.model.vaccination.VaxTypeManager;
 
 
@@ -36,6 +37,7 @@ public class JsonVaxTypeStorage implements VaxTypeStorage {
 
     @Override
     public void saveVaxTypes(VaxTypeManager manager) throws IOException {
+        FileUtil.createIfMissing(USER_FILE_PATH);
         VaxTypeLoader.fromModelType(manager).write(USER_FILE_PATH);
     }
 }

--- a/src/main/java/seedu/vms/storage/vaccination/VaxTypeLoader.java
+++ b/src/main/java/seedu/vms/storage/vaccination/VaxTypeLoader.java
@@ -2,6 +2,7 @@ package seedu.vms.storage.vaccination;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -22,6 +23,20 @@ public class VaxTypeLoader {
     @JsonCreator
     public VaxTypeLoader(@JsonProperty("types") List<JsonAdaptedVaxType> types) {
         this.types = types;
+    }
+
+
+    /**
+     * Converts the specified {@code VaxTypeManager} to a {@code VaxTypeLoader}.
+     */
+    public static VaxTypeLoader fromModelType(VaxTypeManager manager) {
+        List<JsonAdaptedVaxType> types = manager
+                .asUnmodifiableObservableMap()
+                .values()
+                .stream()
+                .map(vaxType -> JsonAdaptedVaxType.fromModelType(vaxType))
+                .collect(Collectors.toList());
+        return new VaxTypeLoader(types);
     }
 
 
@@ -58,5 +73,15 @@ public class VaxTypeLoader {
             adapted.toModelType(storage);
         }
         return storage;
+    }
+
+
+    /**
+     * Writes the data of this {@code VaxTypeLoader} to the specified file.
+     *
+     * @throws IOexception if an I/O error occurs.
+     */
+    public void write(String pathString) throws IOException {
+        JsonUtil.serializeToFile(pathString, this);
     }
 }

--- a/src/main/java/seedu/vms/storage/vaccination/VaxTypeStorage.java
+++ b/src/main/java/seedu/vms/storage/vaccination/VaxTypeStorage.java
@@ -24,4 +24,12 @@ public interface VaxTypeStorage {
      * @throws RuntimeException if an error occurs.
      */
     public VaxTypeManager loadDefaultVaxTypes() throws RuntimeException;
+
+
+    /**
+     * Saves the specified {@code VaxTypeManager} to hard disk.
+     *
+     * @throws IOException if an I/O error occurs.
+     */
+    public void saveVaxTypes(VaxTypeManager manager) throws IOException;
 }

--- a/src/main/java/seedu/vms/storage/vaccination/VaxTypeStorage.java
+++ b/src/main/java/seedu/vms/storage/vaccination/VaxTypeStorage.java
@@ -4,7 +4,24 @@ import java.io.IOException;
 
 import seedu.vms.model.vaccination.VaxTypeManager;
 
+
+/**
+ * Represents the storage for {@link seedu.vms.model.vaccination.VaxTypeManager}.
+ */
 public interface VaxTypeStorage {
+    /**
+     * Loads the {@code VaxTypeManager} as defined by the user.
+     *
+     * @throws IOException if an I/O error occurs.
+     */
     public VaxTypeManager loadUserVaxTypes() throws IOException;
+
+
+    /**
+     * Loads the {@code VaxTypeManager} as defined in the application
+     * resources.
+     *
+     * @throws RuntimeException if an error occurs.
+     */
     public VaxTypeManager loadDefaultVaxTypes() throws RuntimeException;
 }

--- a/src/main/java/seedu/vms/storage/vaccination/VaxTypeStorage.java
+++ b/src/main/java/seedu/vms/storage/vaccination/VaxTypeStorage.java
@@ -1,0 +1,10 @@
+package seedu.vms.storage.vaccination;
+
+import java.io.IOException;
+
+import seedu.vms.model.vaccination.VaxTypeManager;
+
+public interface VaxTypeStorage {
+    public VaxTypeManager loadUserVaxTypes() throws IOException;
+    public VaxTypeManager loadDefaultVaxTypes() throws RuntimeException;
+}

--- a/src/test/java/seedu/vms/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/vms/logic/LogicManagerTest.java
@@ -31,6 +31,7 @@ import seedu.vms.model.patient.ReadOnlyAddressBook;
 import seedu.vms.storage.JsonAddressBookStorage;
 import seedu.vms.storage.JsonUserPrefsStorage;
 import seedu.vms.storage.StorageManager;
+import seedu.vms.storage.vaccination.JsonVaxTypeStorage;
 import seedu.vms.testutil.PatientBuilder;
 
 public class LogicManagerTest {
@@ -47,7 +48,8 @@ public class LogicManagerTest {
         JsonAddressBookStorage addressBookStorage =
                 new JsonAddressBookStorage(temporaryFolder.resolve("addressBook.json"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefs.json"));
-        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
+        JsonVaxTypeStorage vaxTypeStorage = new JsonVaxTypeStorage();
+        StorageManager storage = new StorageManager(addressBookStorage, vaxTypeStorage, userPrefsStorage);
         logic = new LogicManager(model, storage);
     }
 
@@ -76,7 +78,8 @@ public class LogicManagerTest {
                 new JsonAddressBookIoExceptionThrowingStub(temporaryFolder.resolve("ioExceptionAddressBook.json"));
         JsonUserPrefsStorage userPrefsStorage =
                 new JsonUserPrefsStorage(temporaryFolder.resolve("ioExceptionUserPrefs.json"));
-        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
+        JsonVaxTypeStorage vaxTypeStorage = new JsonVaxTypeStorage();
+        StorageManager storage = new StorageManager(addressBookStorage, vaxTypeStorage, userPrefsStorage);
         logic = new LogicManager(model, storage);
 
         // Execute add command

--- a/src/test/java/seedu/vms/logic/commands/patient/AddCommandTest.java
+++ b/src/test/java/seedu/vms/logic/commands/patient/AddCommandTest.java
@@ -23,6 +23,7 @@ import seedu.vms.model.patient.AddressBook;
 import seedu.vms.model.patient.Patient;
 import seedu.vms.model.patient.ReadOnlyAddressBook;
 import seedu.vms.model.vaccination.VaxType;
+import seedu.vms.model.vaccination.VaxTypeManager;
 import seedu.vms.testutil.PatientBuilder;
 
 public class AddCommandTest {
@@ -143,6 +144,11 @@ public class AddCommandTest {
 
         @Override
         public ObservableMap<String, VaxType> getFilteredVaxTypeMap() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public VaxTypeManager getVaxTypeManager() {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/vms/model/vaccination/VaxTypeTest.java
+++ b/src/test/java/seedu/vms/model/vaccination/VaxTypeTest.java
@@ -1,0 +1,115 @@
+package seedu.vms.model.vaccination;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.vms.testutil.SampleVaxTypeData;
+
+public class VaxTypeTest {
+
+
+    @Test
+    public void equalsTest() {
+        VaxType testing = new VaxType(
+                SampleVaxTypeData.NAME_REAL,
+                SampleVaxTypeData.GROUPS_REAL,
+                SampleVaxTypeData.MIN_AGE_REAL,
+                SampleVaxTypeData.MAX_AGE_REAL,
+                SampleVaxTypeData.MIN_SPACING_REAL,
+                SampleVaxTypeData.ALLERGY_REQS_REAL,
+                SampleVaxTypeData.HISTORY_REQS_REAL);
+        List<VaxType> vaxTypes = permutateVaxType();
+
+        assertTrue(testing.equals(testing));
+        assertTrue(testing.equals(vaxTypes.get(0)));
+        for (int i = 1; i < vaxTypes.size(); i++) {
+            assertFalse(testing.equals(vaxTypes.get(i)));
+        }
+
+        assertFalse(testing.equals(Integer.valueOf(0)));
+    }
+
+
+    @Test
+    public void hashCodeTest() {
+        List<VaxType> vaxTypes = permutateVaxType();
+        HashSet<VaxType> vaxTypeSet = new HashSet<>(vaxTypes);
+        vaxTypeSet.addAll(vaxTypes);
+
+        assertTrue(vaxTypeSet.size() == vaxTypes.size());
+    }
+
+
+    private List<VaxType> permutateVaxType() {
+        VaxType t1 = new VaxType(
+                SampleVaxTypeData.NAME_REAL,
+                SampleVaxTypeData.GROUPS_REAL,
+                SampleVaxTypeData.MIN_AGE_REAL,
+                SampleVaxTypeData.MAX_AGE_REAL,
+                SampleVaxTypeData.MIN_SPACING_REAL,
+                SampleVaxTypeData.ALLERGY_REQS_REAL,
+                SampleVaxTypeData.HISTORY_REQS_REAL);
+        VaxType t2 = new VaxType(
+                SampleVaxTypeData.NAME_1,
+                SampleVaxTypeData.GROUPS_REAL,
+                SampleVaxTypeData.MIN_AGE_REAL,
+                SampleVaxTypeData.MAX_AGE_REAL,
+                SampleVaxTypeData.MIN_SPACING_REAL,
+                SampleVaxTypeData.ALLERGY_REQS_REAL,
+                SampleVaxTypeData.HISTORY_REQS_REAL);
+        VaxType t3 = new VaxType(
+                SampleVaxTypeData.NAME_REAL,
+                SampleVaxTypeData.GROUPS_1,
+                SampleVaxTypeData.MIN_AGE_REAL,
+                SampleVaxTypeData.MAX_AGE_REAL,
+                SampleVaxTypeData.MIN_SPACING_REAL,
+                SampleVaxTypeData.ALLERGY_REQS_REAL,
+                SampleVaxTypeData.HISTORY_REQS_REAL);
+        VaxType t4 = new VaxType(
+                SampleVaxTypeData.NAME_REAL,
+                SampleVaxTypeData.GROUPS_REAL,
+                SampleVaxTypeData.MIN_AGE_1,
+                SampleVaxTypeData.MAX_AGE_REAL,
+                SampleVaxTypeData.MIN_SPACING_REAL,
+                SampleVaxTypeData.ALLERGY_REQS_REAL,
+                SampleVaxTypeData.HISTORY_REQS_REAL);
+        VaxType t5 = new VaxType(
+                SampleVaxTypeData.NAME_REAL,
+                SampleVaxTypeData.GROUPS_REAL,
+                SampleVaxTypeData.MIN_AGE_REAL,
+                SampleVaxTypeData.MAX_AGE_1,
+                SampleVaxTypeData.MIN_SPACING_REAL,
+                SampleVaxTypeData.ALLERGY_REQS_REAL,
+                SampleVaxTypeData.HISTORY_REQS_REAL);
+        VaxType t6 = new VaxType(
+                SampleVaxTypeData.NAME_REAL,
+                SampleVaxTypeData.GROUPS_REAL,
+                SampleVaxTypeData.MIN_AGE_REAL,
+                SampleVaxTypeData.MAX_AGE_REAL,
+                SampleVaxTypeData.MIN_SPACING_1,
+                SampleVaxTypeData.ALLERGY_REQS_REAL,
+                SampleVaxTypeData.HISTORY_REQS_REAL);
+        VaxType t7 = new VaxType(
+                SampleVaxTypeData.NAME_REAL,
+                SampleVaxTypeData.GROUPS_REAL,
+                SampleVaxTypeData.MIN_AGE_REAL,
+                SampleVaxTypeData.MAX_AGE_REAL,
+                SampleVaxTypeData.MIN_SPACING_REAL,
+                SampleVaxTypeData.ALLERGY_REQS_1,
+                SampleVaxTypeData.HISTORY_REQS_REAL);
+        VaxType t8 = new VaxType(
+                SampleVaxTypeData.NAME_REAL,
+                SampleVaxTypeData.GROUPS_REAL,
+                SampleVaxTypeData.MIN_AGE_REAL,
+                SampleVaxTypeData.MAX_AGE_REAL,
+                SampleVaxTypeData.MIN_SPACING_REAL,
+                SampleVaxTypeData.ALLERGY_REQS_REAL,
+                SampleVaxTypeData.HISTORY_REQS_1);
+        return List.of(t1, t2, t3, t4, t5, t6, t7, t8);
+    }
+}

--- a/src/test/java/seedu/vms/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/vms/storage/StorageManagerTest.java
@@ -78,7 +78,7 @@ public class StorageManagerTest {
          */
         Optional<VaxType> data = storageManager
                 .loadDefaultVaxTypes()
-                .get(SampleVaxTypeData.NAME);
+                .get(SampleVaxTypeData.NAME_REAL);
         assertTrue(data.isPresent());
     }
 

--- a/src/test/java/seedu/vms/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/vms/storage/StorageManagerTest.java
@@ -17,6 +17,7 @@ import seedu.vms.model.UserPrefs;
 import seedu.vms.model.patient.AddressBook;
 import seedu.vms.model.patient.ReadOnlyAddressBook;
 import seedu.vms.model.vaccination.VaxType;
+import seedu.vms.storage.vaccination.JsonVaxTypeStorage;
 import seedu.vms.testutil.SampleVaxTypeData;
 
 public class StorageManagerTest {
@@ -30,7 +31,8 @@ public class StorageManagerTest {
     public void setUp() {
         JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(getTempFilePath("ab"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(getTempFilePath("prefs"));
-        storageManager = new StorageManager(addressBookStorage, userPrefsStorage);
+        JsonVaxTypeStorage vaxTypeStorage = new JsonVaxTypeStorage();
+        storageManager = new StorageManager(addressBookStorage, vaxTypeStorage, userPrefsStorage);
     }
 
     private Path getTempFilePath(String fileName) {

--- a/src/test/java/seedu/vms/storage/vaccination/VaxTypeLoaderTest.java
+++ b/src/test/java/seedu/vms/storage/vaccination/VaxTypeLoaderTest.java
@@ -1,10 +1,13 @@
 package seedu.vms.storage.vaccination;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import seedu.vms.commons.exceptions.IllegalValueException;
 import seedu.vms.model.vaccination.VaxTestingUtil;
@@ -30,6 +33,11 @@ public class VaxTypeLoaderTest {
 
     private static final String FILE_VALID_MULTIPLE = "ValidMultipleTypes.json";
     private static final String FILE_EMPTY = "ZeroTypes.json";
+
+    private static final String TEST_SAVE_FILE = "VAX_TYPE_TEST_FILE.json";
+
+    @TempDir
+    public Path testFolder;
 
 
     @Test
@@ -167,5 +175,23 @@ public class VaxTypeLoaderTest {
             // expected exception
             return;
         }
+    }
+
+
+    @Test
+    public void write() throws Exception {
+        // empty manager
+        testSaveMethod(new VaxTypeManager());
+        // filled manager
+        // assuming default loading works
+        testSaveMethod(VaxTypeLoader.load());
+    }
+
+
+    private void testSaveMethod(VaxTypeManager manager) throws Exception {
+        Path saveFile = testFolder.resolve(TEST_SAVE_FILE);
+        VaxTypeLoader.fromModelType(manager).write(saveFile.toString());
+        VaxTypeManager loaded = VaxTypeLoader.load(saveFile.toString());
+        assertEquals(manager.asUnmodifiableObservableMap(), loaded.asUnmodifiableObservableMap());
     }
 }

--- a/src/test/java/seedu/vms/storage/vaccination/VaxTypeLoaderTest.java
+++ b/src/test/java/seedu/vms/storage/vaccination/VaxTypeLoaderTest.java
@@ -43,15 +43,15 @@ public class VaxTypeLoaderTest {
     @Test
     public void load_resource() throws Exception {
         VaxTypeManager storage = VaxTypeLoader.load();
-        VaxType vaxType = storage.get(SampleVaxTypeData.NAME).get();
+        VaxType vaxType = storage.get(SampleVaxTypeData.NAME_REAL).get();
         VaxTestingUtil.assertVaxType(vaxType,
-                SampleVaxTypeData.NAME,
-                SampleVaxTypeData.GROUPS,
-                SampleVaxTypeData.MIN_AGE,
-                SampleVaxTypeData.MAX_AGE,
-                SampleVaxTypeData.MIN_SPACING,
-                SampleVaxTypeData.HISTORY_REQS,
-                SampleVaxTypeData.ALLERGY_REQS);
+                SampleVaxTypeData.NAME_REAL,
+                SampleVaxTypeData.GROUPS_REAL,
+                SampleVaxTypeData.MIN_AGE_REAL,
+                SampleVaxTypeData.MAX_AGE_REAL,
+                SampleVaxTypeData.MIN_SPACING_REAL,
+                SampleVaxTypeData.HISTORY_REQS_REAL,
+                SampleVaxTypeData.ALLERGY_REQS_REAL);
     }
 
 
@@ -82,15 +82,15 @@ public class VaxTypeLoaderTest {
                 VaxType.DEFAULT_MIN_SPACING,
                 VaxType.DEFAULT_HISTORY_REQS,
                 VaxType.DEFAULT_ALLERGY_REQS);
-        vaxType = storage.get(SampleVaxTypeData.NAME).get();
+        vaxType = storage.get(SampleVaxTypeData.NAME_REAL).get();
         VaxTestingUtil.assertVaxType(vaxType,
-                SampleVaxTypeData.NAME,
-                SampleVaxTypeData.GROUPS,
-                SampleVaxTypeData.MIN_AGE,
-                SampleVaxTypeData.MAX_AGE,
-                SampleVaxTypeData.MIN_SPACING,
-                SampleVaxTypeData.HISTORY_REQS,
-                SampleVaxTypeData.ALLERGY_REQS);
+                SampleVaxTypeData.NAME_REAL,
+                SampleVaxTypeData.GROUPS_REAL,
+                SampleVaxTypeData.MIN_AGE_REAL,
+                SampleVaxTypeData.MAX_AGE_REAL,
+                SampleVaxTypeData.MIN_SPACING_REAL,
+                SampleVaxTypeData.HISTORY_REQS_REAL,
+                SampleVaxTypeData.ALLERGY_REQS_REAL);
     }
 
 

--- a/src/test/java/seedu/vms/testutil/SampleVaxTypeData.java
+++ b/src/test/java/seedu/vms/testutil/SampleVaxTypeData.java
@@ -8,15 +8,15 @@ import seedu.vms.model.vaccination.Requirement.RequirementType;
 
 /** Utility class to store sample vaccination type data for tests. */
 public class SampleVaxTypeData {
-    public static final String NAME = "Dose 1 (Pfizer)";
-    public static final HashSet<String> GROUPS =
+    public static final String NAME_REAL = "Dose 1 (Pfizer)";
+    public static final HashSet<String> GROUPS_REAL =
             new HashSet<>(List.of("DOSE 1", "Pfizer", "Vaccination"));
-    public static final int MIN_AGE = 5;
-    public static final int MAX_AGE = Integer.MAX_VALUE;
-    public static final int MIN_SPACING = 56;
-    public static final List<Requirement> HISTORY_REQS = List.of(
+    public static final int MIN_AGE_REAL = 5;
+    public static final int MAX_AGE_REAL = Integer.MAX_VALUE;
+    public static final int MIN_SPACING_REAL = 56;
+    public static final List<Requirement> HISTORY_REQS_REAL = List.of(
             new Requirement(RequirementType.NONE, new HashSet<>(List.of("DOSE 1"))));
-    public static final List<Requirement> ALLERGY_REQS = List.of(
+    public static final List<Requirement> ALLERGY_REQS_REAL = List.of(
             new Requirement(RequirementType.NONE, new HashSet<>(List.of(
                     "((4-Hydroxybutyl)azanediyl)bis(hexane-6,1-diyl)bis(2-hexyldecanoate)",
                     "2-[(polyethylene glycol)-2000]-N,N-ditetradecylacetamide",
@@ -26,4 +26,16 @@ public class SampleVaxTypeData {
                     "Phosphate",
                     "Tromethamine",
                     "Tris(hydroxymethyl)aminoethane hydrochloride"))));
+
+    public static final String NAME_1 = "UNCHI";
+    public static final HashSet<String> GROUPS_1 =
+            new HashSet<>(List.of("UNCHI"));
+    public static final int MIN_AGE_1 = 35;
+    public static final int MAX_AGE_1 = 45;
+    public static final int MIN_SPACING_1 = 3545;
+    public static final List<Requirement> HISTORY_REQS_1 = List.of(
+            new Requirement(RequirementType.NONE, new HashSet<>(List.of("UNCHI"))));
+    public static final List<Requirement> ALLERGY_REQS_1 = List.of(
+            new Requirement(RequirementType.NONE, new HashSet<>(List.of(
+                    "UNCHI"))));
 }


### PR DESCRIPTION
### Issues resolved
* Resolves #92 
* Resolves #83 

### Significant changes

* Added write method to `VaxTypeLoader` to write save a state of `VaxTypeManager` to hard disk.
* Changed constructor signature of `StorageManager` to require `VaxTypeStorage` as well.
* Integrated read and write from and to user files from `VaxTypeLoader` to applicaiton.

### Testing

#### VaxTypeLoader

Automated testing created to write sample `VaxTypeManager` to file and load it back, ensure that they are the same.

#### Integration

Manual testing done.

1. Delete the entire data folder that the app creates if it exists.
2. Launch the app.
3. Enter the command:
```text
help
```
4. Check that the data file for vaccination types has been created in `data` > `vaxtype.json`.
5. Replace the contents of `vaxtype.json` with the following:
```json
{
  "types" : [
    {
      "name": "UNCHI"
    }
  ]
}
```
6. Launch the app and check that UNCHI is present with no attributes.
7. Close the app and delete any brackets in `vaxtype.json`.
8. Launch the app and check that the default vaccination type has been loaded.