### PR TITLE
Basic add vaccination type command

### DIFF
--- a/src/main/java/seedu/vms/logic/commands/vaccination/AddVaxTypeCommand.java
+++ b/src/main/java/seedu/vms/logic/commands/vaccination/AddVaxTypeCommand.java
@@ -1,0 +1,39 @@
+package seedu.vms.logic.commands.vaccination;
+
+import java.util.Objects;
+
+import seedu.vms.commons.exceptions.IllegalValueException;
+import seedu.vms.logic.commands.Command;
+import seedu.vms.logic.commands.CommandResult;
+import seedu.vms.logic.commands.exceptions.CommandException;
+import seedu.vms.model.Model;
+import seedu.vms.model.vaccination.VaxType;
+import seedu.vms.model.vaccination.VaxTypeBuilder;
+
+
+/**
+ * Command to add a vaccination type.
+ */
+public class AddVaxTypeCommand extends Command {
+    public static final String MESSAGE_SUCCESS = "Vaccination type successfully added: %s";
+
+    private final VaxTypeBuilder builder;
+
+
+    public AddVaxTypeCommand(VaxTypeBuilder builder) {
+        this.builder = Objects.requireNonNull(builder);
+    }
+
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        Objects.requireNonNull(model);
+
+        try {
+            VaxType vaxType = model.performVaxTypeAction(builder::create);
+            return new CommandResult(String.format(MESSAGE_SUCCESS, vaxType.toString()));
+        } catch (IllegalValueException ive) {
+            throw new CommandException(ive.getMessage(), ive);
+        }
+    }
+}

--- a/src/main/java/seedu/vms/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/vms/logic/parser/ParserUtil.java
@@ -17,6 +17,7 @@ import seedu.vms.model.patient.Email;
 import seedu.vms.model.patient.Name;
 import seedu.vms.model.patient.Phone;
 import seedu.vms.model.tag.Tag;
+import seedu.vms.model.vaccination.VaxName;
 
 /**
  * Contains utility methods used for parsing strings in the various *Parser classes.
@@ -169,5 +170,14 @@ public class ParserUtil {
                     DateTimeFormatter.ofPattern(FULL_DATE_PATTERN));
         }
         throw new ParseException(MESSAGE_INVALID_DATE);
+    }
+
+
+    public static VaxName parseVaxName(String name) throws ParseException {
+        requireNonNull(name);
+        if (!VaxName.isValidName(name)) {
+            throw new ParseException(VaxName.MESSAGE_CONSTRAINT);
+        }
+        return new VaxName(name);
     }
 }

--- a/src/main/java/seedu/vms/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/vms/logic/parser/ParserUtil.java
@@ -173,6 +173,12 @@ public class ParserUtil {
     }
 
 
+    /**
+     * Parses vaccination type names.
+     *
+     * @param name - name to parse.
+     * @throws ParseException if the name cannot be parsed.
+     */
     public static VaxName parseVaxName(String name) throws ParseException {
         requireNonNull(name);
         if (!VaxName.isValidName(name)) {

--- a/src/main/java/seedu/vms/logic/parser/VmsParser.java
+++ b/src/main/java/seedu/vms/logic/parser/VmsParser.java
@@ -9,6 +9,7 @@ import seedu.vms.logic.commands.basic.HelpCommand;
 import seedu.vms.logic.parser.basic.BasicParser;
 import seedu.vms.logic.parser.exceptions.ParseException;
 import seedu.vms.logic.parser.patient.PatientParser;
+import seedu.vms.logic.parser.vaccination.VaccinationParser;
 
 
 /** Parsers user input.  */
@@ -18,6 +19,7 @@ public class VmsParser {
 
     private final BasicParser basicParser = new BasicParser();
     private final PatientParser patientParser = new PatientParser();
+    private final VaccinationParser vaccinationParser = new VaccinationParser();
 
     /**
      * Parses user input into command for execution.
@@ -39,6 +41,9 @@ public class VmsParser {
 
         case PatientParser.FEATURE_NAME:
             return patientParser.parse(arguments);
+
+        case VaccinationParser.FEATURE_NAME:
+            return vaccinationParser.parse(arguments);
 
         default:
             return basicParser.parse(userInput);

--- a/src/main/java/seedu/vms/logic/parser/vaccination/AddVaxTypeParser.java
+++ b/src/main/java/seedu/vms/logic/parser/vaccination/AddVaxTypeParser.java
@@ -1,0 +1,30 @@
+package seedu.vms.logic.parser.vaccination;
+
+import seedu.vms.logic.commands.vaccination.AddVaxTypeCommand;
+import seedu.vms.logic.parser.ArgumentMultimap;
+import seedu.vms.logic.parser.ArgumentTokenizer;
+import seedu.vms.logic.parser.Parser;
+import seedu.vms.logic.parser.ParserUtil;
+import seedu.vms.logic.parser.exceptions.ParseException;
+import seedu.vms.model.vaccination.VaxName;
+import seedu.vms.model.vaccination.VaxTypeBuilder;
+
+
+/**
+ * Parser of vaccination type add command arguments.
+ */
+public class AddVaxTypeParser implements Parser<AddVaxTypeCommand> {
+    public static final String COMMAND_WORD = "add";
+
+
+    @Override
+    public AddVaxTypeCommand parse(String args) throws ParseException {
+        ArgumentMultimap argsMap = ArgumentTokenizer.tokenize(args);
+
+        VaxName name = ParserUtil.parseVaxName(argsMap.getPreamble());
+
+        VaxTypeBuilder builder = VaxTypeBuilder.of(name);
+
+        return new AddVaxTypeCommand(builder);
+    }
+}

--- a/src/main/java/seedu/vms/logic/parser/vaccination/VaccinationParser.java
+++ b/src/main/java/seedu/vms/logic/parser/vaccination/VaccinationParser.java
@@ -1,0 +1,27 @@
+package seedu.vms.logic.parser.vaccination;
+
+import seedu.vms.commons.core.Messages;
+import seedu.vms.logic.commands.Command;
+import seedu.vms.logic.parser.FeatureParser;
+import seedu.vms.logic.parser.exceptions.ParseException;
+
+
+/**
+ * Parser of vaccination feature commands.
+ */
+public class VaccinationParser extends FeatureParser {
+    public static final String FEATURE_NAME = "vaccination";
+
+
+    @Override
+    public Command parseCommand(String commandWord, String arguments) throws ParseException {
+        switch (commandWord) {
+
+        case AddVaxTypeParser.COMMAND_WORD:
+            return new AddVaxTypeParser().parse(arguments);
+
+        default:
+            throw new ParseException(Messages.MESSAGE_UNKNOWN_COMMAND);
+        }
+    }
+}

--- a/src/main/java/seedu/vms/model/Model.java
+++ b/src/main/java/seedu/vms/model/Model.java
@@ -5,9 +5,11 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableMap;
 import seedu.vms.commons.core.GuiSettings;
+import seedu.vms.commons.exceptions.IllegalValueException;
 import seedu.vms.model.patient.Patient;
 import seedu.vms.model.patient.ReadOnlyAddressBook;
 import seedu.vms.model.vaccination.VaxType;
+import seedu.vms.model.vaccination.VaxTypeAction;
 import seedu.vms.model.vaccination.VaxTypeManager;
 
 /**
@@ -94,4 +96,7 @@ public interface Model {
 
     /** Returns the {@code VaxTypeManager} the model is using. */
     VaxTypeManager getVaxTypeManager();
+
+    /** Performs the specified action of the {@code VaxTypeManager} that the model is using. */
+    VaxType performVaxTypeAction(VaxTypeAction action) throws IllegalValueException;
 }

--- a/src/main/java/seedu/vms/model/ModelManager.java
+++ b/src/main/java/seedu/vms/model/ModelManager.java
@@ -10,10 +10,12 @@ import java.util.logging.Logger;
 import javafx.collections.ObservableMap;
 import seedu.vms.commons.core.GuiSettings;
 import seedu.vms.commons.core.LogsCenter;
+import seedu.vms.commons.exceptions.IllegalValueException;
 import seedu.vms.model.patient.AddressBook;
 import seedu.vms.model.patient.Patient;
 import seedu.vms.model.patient.ReadOnlyAddressBook;
 import seedu.vms.model.vaccination.VaxType;
+import seedu.vms.model.vaccination.VaxTypeAction;
 import seedu.vms.model.vaccination.VaxTypeManager;
 
 /**
@@ -124,6 +126,16 @@ public class ModelManager implements Model {
 
         addressBook.set(id, editedPatient);
     }
+
+
+    //=========== VaxTypeManager ==============================================================================
+
+
+    @Override
+    public VaxType performVaxTypeAction(VaxTypeAction action) throws IllegalValueException {
+        return action.apply(vaxTypeManager);
+    }
+
 
     //=========== Filtered Patient List Accessors =============================================================
 

--- a/src/main/java/seedu/vms/model/vaccination/VaxName.java
+++ b/src/main/java/seedu/vms/model/vaccination/VaxName.java
@@ -1,0 +1,57 @@
+package seedu.vms.model.vaccination;
+
+import java.util.Objects;
+
+import seedu.vms.commons.util.AppUtil;
+
+
+/**
+ * Represents a vaccination name. The validity of the name is enforced.
+ */
+public class VaxName {
+    public static final String MESSAGE_CONSTRAINT = "Vaccination name should not be blank, "
+            + "and should only contain alphanumeric characters including brackets and dashes";
+
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}\\(\\)\\[\\]\\{\\}<>\\-_ ]{1,30}";
+
+
+    private final String name;
+
+
+    /**
+     * Constructs a {@code VaxName}.
+     *
+     * @param name - name of vaccination.
+     */
+    public VaxName(String name) {
+        Objects.requireNonNull(name);
+        AppUtil.checkArgument(isValidName(name), MESSAGE_CONSTRAINT);
+        this.name = name.strip();
+    }
+
+    public static boolean isValidName(String name) {
+        return name.strip().matches(VALIDATION_REGEX);
+    }
+
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return false;
+        }
+        return other instanceof VaxName
+                && name.equals(((VaxName) other).name);
+    }
+
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+}

--- a/src/main/java/seedu/vms/model/vaccination/VaxName.java
+++ b/src/main/java/seedu/vms/model/vaccination/VaxName.java
@@ -2,6 +2,9 @@ package seedu.vms.model.vaccination;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 import seedu.vms.commons.util.AppUtil;
 
 
@@ -23,6 +26,7 @@ public class VaxName {
      *
      * @param name - name of vaccination.
      */
+    @JsonCreator
     public VaxName(String name) {
         Objects.requireNonNull(name);
         AppUtil.checkArgument(isValidName(name), MESSAGE_CONSTRAINT);
@@ -31,6 +35,12 @@ public class VaxName {
 
     public static boolean isValidName(String name) {
         return name.strip().matches(VALIDATION_REGEX);
+    }
+
+
+    @JsonValue
+    public String getName() {
+        return name;
     }
 
 

--- a/src/main/java/seedu/vms/model/vaccination/VaxName.java
+++ b/src/main/java/seedu/vms/model/vaccination/VaxName.java
@@ -43,7 +43,7 @@ public class VaxName {
     @Override
     public boolean equals(Object other) {
         if (this == other) {
-            return false;
+            return true;
         }
         return other instanceof VaxName
                 && name.equals(((VaxName) other).name);

--- a/src/main/java/seedu/vms/model/vaccination/VaxRecordKey.java
+++ b/src/main/java/seedu/vms/model/vaccination/VaxRecordKey.java
@@ -9,7 +9,7 @@ import java.util.Objects;
  * {@link VaxType} instead of the instance.
  */
 public class VaxRecordKey {
-    private final String vaxKey;
+    private final VaxName vaxKey;
     private final LocalDateTime timeTaken;
 
 
@@ -20,14 +20,14 @@ public class VaxRecordKey {
      * @param timeTaken - the time the vaccination was taken.
      * @throws NullPointerException if any parameters are {@code null}.
      */
-    public VaxRecordKey(String vaxKey, LocalDateTime timeTaken) {
+    public VaxRecordKey(VaxName vaxKey, LocalDateTime timeTaken) {
         this.vaxKey = Objects.requireNonNull(vaxKey);;
         this.timeTaken = Objects.requireNonNull(timeTaken);
     }
 
 
     public String getVaxTypeKey() {
-        return vaxKey;
+        return vaxKey.toString();
     }
 
 

--- a/src/main/java/seedu/vms/model/vaccination/VaxType.java
+++ b/src/main/java/seedu/vms/model/vaccination/VaxType.java
@@ -16,7 +16,7 @@ public class VaxType {
     public static final List<Requirement> DEFAULT_HISTORY_REQS = List.of();
     public static final List<Requirement> DEFAULT_ALLERGY_REQS = List.of();
 
-    private final String name;
+    private final VaxName name;
     private final HashSet<String> groups;
     private final int minAge;
     private final int maxAge;
@@ -28,7 +28,7 @@ public class VaxType {
     /**
      * Constructs a {@code VaxType}.
      */
-    public VaxType(String name, HashSet<String> groups,
+    public VaxType(VaxName name, HashSet<String> groups,
                 int minAge, int maxAge, int minSpacing,
                 List<Requirement> allergyReqs, List<Requirement> historyReqs) {
         this.name = name;
@@ -41,8 +41,19 @@ public class VaxType {
     }
 
 
+    /**
+     * Constructs a {@code VaxType}. The given name is converted to a
+     * {@code VaxName}.
+     */
+    public VaxType(String name, HashSet<String> groups,
+            int minAge, int maxAge, int minSpacing,
+            List<Requirement> allergyReqs, List<Requirement> historyReqs) {
+        this(new VaxName(name), groups, minAge, maxAge, minSpacing, allergyReqs, historyReqs);
+    }
+
+
     public String getName() {
-        return name;
+        return name.toString();
     }
 
 
@@ -78,7 +89,7 @@ public class VaxType {
 
     @Override
     public String toString() {
-        return name;
+        return name.toString();
     }
 
 

--- a/src/main/java/seedu/vms/model/vaccination/VaxTypeAction.java
+++ b/src/main/java/seedu/vms/model/vaccination/VaxTypeAction.java
@@ -1,0 +1,19 @@
+package seedu.vms.model.vaccination;
+
+import seedu.vms.commons.exceptions.IllegalValueException;
+
+
+/**
+ * Similar to {@link java.util.function.Function} however functional method may
+ * throw an exception.
+ */
+@FunctionalInterface
+public interface VaxTypeAction {
+    /**
+     * Performs an action of the given {@code VaxTypeManager}.
+     *
+     * @param manager - the manager to work on.
+     * @throws IllegalValueException illegal values are present.
+     */
+    public VaxType apply(VaxTypeManager manager) throws IllegalValueException;
+}

--- a/src/main/java/seedu/vms/model/vaccination/VaxTypeBuilder.java
+++ b/src/main/java/seedu/vms/model/vaccination/VaxTypeBuilder.java
@@ -4,128 +4,172 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 
+import seedu.vms.commons.exceptions.IllegalValueException;
+
 
 /**
  * A factory class to create, rename or edit {@link VaxType} to its set
  * {@link VaxTypeManager}.
  */
 public class VaxTypeBuilder {
-    private final VaxTypeManager storage;
-    private final Optional<String> oriName;
+    private static final String MESSAGE_DUPLICATE_TYPE = "Vaccination type already exist";
+    private static final String MESSAGE_MISSING_TYPE = "Vaccination type does not exist";
+
+    private final String refName;
 
     private final String name;
-    private final HashSet<String> grps;
-    private final int minAge;
-    private final int maxAge;
-    private final int minSpacing;
-    private final List<Requirement> allergyReqs;
-    private final List<Requirement> historyReqs;
+    private final Optional<HashSet<String>> setGrps;
+    private final Optional<Integer> setMinAge;
+    private final Optional<Integer> setMaxAge;
+    private final Optional<Integer> setMinSpacing;
+    private final Optional<List<Requirement>> setAllergyReqs;
+    private final Optional<List<Requirement>> setHistoryReqs;
 
 
-    private VaxTypeBuilder(VaxTypeManager storage, Optional<String> oriName,
-                String name, HashSet<String> grps, int minAge, int maxAge, int minSpacing,
-                List<Requirement> allergyReqs, List<Requirement> historyReqs) {
-        this.storage = storage;
-        this.oriName = oriName;
+    private VaxTypeBuilder(String refName, String name, Optional<HashSet<String>> setGrps,
+                Optional<Integer> setMinAge, Optional<Integer> setMaxAge, Optional<Integer> setMinSpacing,
+                Optional<List<Requirement>> setAllergyReqs, Optional<List<Requirement>> setHistoryReqs) {
+        this.refName = refName;
         this.name = name;
-        this.grps = new HashSet<>(grps);
-        this.minAge = minAge;
-        this.maxAge = maxAge;
-        this.minSpacing = minSpacing;
-        this.allergyReqs = Requirement.copy(allergyReqs);
-        this.historyReqs = Requirement.copy(historyReqs);
+        this.setGrps = setGrps.map(HashSet::new);
+        this.setMinAge = setMinAge;
+        this.setMaxAge = setMaxAge;
+        this.setMinSpacing = setMinSpacing;
+        this.setAllergyReqs = setAllergyReqs.map(Requirement::copy);
+        this.setHistoryReqs = setHistoryReqs.map(Requirement::copy);
     }
 
 
     /**
      * Factory method to create a {@code VaxTypeBuilder}.
      *
-     * @param storage - the {@code VaxTypeManager} the builder should be
-     *      bounded to.
-     * @param name - the name of the {@code VaxType} to create/override from
-     *      in the specified storage.
+     * @param refName - the name of the existing vaccination type to build
+     *      from.
+     * @param name - the name of the {@code VaxType} to create.
      */
-    public static VaxTypeBuilder of(VaxTypeManager storage, String name) {
-        Optional<VaxType> vaxType = storage.get(name);
-        Optional<String> oriName = vaxType.map(VaxType::getName);
-        HashSet<String> grps = vaxType.map(VaxType::getGroups)
-                .orElse(VaxType.DEFAULT_GROUP_SET);
-        int minAge = vaxType.map(VaxType::getMinAge)
-                .orElse(VaxType.DEFAULT_MIN_AGE);
-        int maxAge = vaxType.map(VaxType::getMaxAge)
-                .orElse(VaxType.DEFAULT_MAX_AGE);
-        int minSpacing = vaxType.map(VaxType::getMinSpacing)
-                .orElse(VaxType.DEFAULT_MIN_SPACING);
-        List<Requirement> allergyReqs = vaxType.map(VaxType::getAllergyReqs)
-                .orElse(VaxType.DEFAULT_ALLERGY_REQS);
-        List<Requirement> historyReqs = vaxType.map(VaxType::getHistoryReqs)
-                .orElse(VaxType.DEFAULT_HISTORY_REQS);
-
-        return new VaxTypeBuilder(storage, oriName,
-                name, grps, minAge, maxAge, minSpacing,
-                allergyReqs, historyReqs);
-    }
-
-
-    public VaxTypeBuilder setName(String name) {
-        return new VaxTypeBuilder(storage, oriName,
-                name, grps, minAge, maxAge, minSpacing,
-                allergyReqs, historyReqs);
-    }
-
-
-    public VaxTypeBuilder setGroups(HashSet<String> grps) {
-        return new VaxTypeBuilder(storage, oriName,
-                name, grps, minAge, maxAge, minSpacing,
-                allergyReqs, historyReqs);
-    }
-
-
-    public VaxTypeBuilder setMinAge(int minAge) {
-        return new VaxTypeBuilder(storage, oriName,
-                name, grps, minAge, maxAge, minSpacing,
-                allergyReqs, historyReqs);
-    }
-
-
-    public VaxTypeBuilder setMaxAge(int maxAge) {
-        return new VaxTypeBuilder(storage, oriName,
-                name, grps, minAge, maxAge, minSpacing,
-                allergyReqs, historyReqs);
-    }
-
-
-    public VaxTypeBuilder setMinSpacing(int minSpacing) {
-        return new VaxTypeBuilder(storage, oriName,
-                name, grps, minAge, maxAge, minSpacing,
-                allergyReqs, historyReqs);
-    }
-
-
-    public VaxTypeBuilder setAllergyReqs(List<Requirement> allergyReqs) {
-        return new VaxTypeBuilder(storage, oriName,
-                name, grps, minAge, maxAge, minSpacing,
-                allergyReqs, historyReqs);
-    }
-
-
-    public VaxTypeBuilder setHistoryReqs(List<Requirement> historyReqs) {
-        return new VaxTypeBuilder(storage, oriName,
-                name, grps, minAge, maxAge, minSpacing,
-                allergyReqs, historyReqs);
+    public static VaxTypeBuilder of(String refName, String name) {
+        return new VaxTypeBuilder(refName, name,
+                Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.empty(), Optional.empty(), Optional.empty());
     }
 
 
     /**
-     * Builds and adds the {@code VaxType} to the bounded storage.
+     * Factory method to create a {@code VaxTypeBuilder} without a reference.
      *
-     * @return the {@code VaxType} built.
+     * @param name - the name of the {@code VaxType} to create.
      */
-    public VaxType build() {
-        oriName.ifPresent(storage::remove);
-        VaxType vaxType = new VaxType(name, grps, minAge, maxAge, minSpacing,
-                allergyReqs, historyReqs);
-        storage.add(vaxType);
+    public static VaxTypeBuilder of(String name) {
+        return VaxTypeBuilder.of(name, name);
+    }
+
+
+    public VaxTypeBuilder setName(String name) {
+        return new VaxTypeBuilder(refName, name, setGrps,
+                setMinAge, setMaxAge, setMinSpacing,
+                setAllergyReqs, setHistoryReqs);
+    }
+
+
+    public VaxTypeBuilder setGroups(HashSet<String> grps) {
+        return new VaxTypeBuilder(refName, name, Optional.ofNullable(grps),
+                setMinAge, setMaxAge, setMinSpacing,
+                setAllergyReqs, setHistoryReqs);
+    }
+
+
+    public VaxTypeBuilder setMinAge(int minAge) {
+        return new VaxTypeBuilder(refName, name, setGrps,
+                Optional.ofNullable(minAge), setMaxAge, setMinSpacing,
+                setAllergyReqs, setHistoryReqs);
+    }
+
+
+    public VaxTypeBuilder setMaxAge(int maxAge) {
+        return new VaxTypeBuilder(refName, name, setGrps,
+                setMinAge, Optional.ofNullable(maxAge), setMinSpacing,
+                setAllergyReqs, setHistoryReqs);
+    }
+
+
+    public VaxTypeBuilder setMinSpacing(int minSpacing) {
+        return new VaxTypeBuilder(refName, name, setGrps,
+                setMinAge, setMaxAge, Optional.ofNullable(minSpacing),
+                setAllergyReqs, setHistoryReqs);
+    }
+
+
+    public VaxTypeBuilder setAllergyReqs(List<Requirement> allergyReqs) {
+        return new VaxTypeBuilder(refName, name, setGrps,
+                setMinAge, setMaxAge, setMinSpacing,
+                Optional.ofNullable(allergyReqs), setHistoryReqs);
+    }
+
+
+    public VaxTypeBuilder setHistoryReqs(List<Requirement> historyReqs) {
+        return new VaxTypeBuilder(refName, name, setGrps,
+                setMinAge, setMaxAge, setMinSpacing,
+                setAllergyReqs, Optional.ofNullable(historyReqs));
+    }
+
+
+    /**
+     * Builds the vaccination type and adds it to the specified
+     * {@code VaxTypeManager}.
+     *
+     * @return the built {@code VaxType}.
+     * @throws IllegalValueException if the a vaccination type might be
+     *      replaced.
+     */
+    public VaxType create(VaxTypeManager manager) throws IllegalValueException {
+        if (manager.contains(refName) || manager.contains(name)) {
+            throw new IllegalValueException(MESSAGE_DUPLICATE_TYPE);
+        }
+        return build(manager);
+    }
+
+
+    /**
+     * Builds and updates the vaccination type in the specified
+     * {@code VaxTypeManager}.
+     *
+     * @return the built {@code VaxType}.
+     * @throws IllegalValueException if the reference vaccination is not
+     *      present or if the vaccination type is being renamed to one that
+     *      already exists.
+     */
+    public VaxType update(VaxTypeManager manager) throws IllegalValueException {
+        if (!manager.contains(refName) || (!refName.equals(name) && manager.contains(name))) {
+            throw new IllegalValueException(MESSAGE_MISSING_TYPE);
+        }
+        return build(manager);
+    }
+
+
+    private VaxType build(VaxTypeManager manager) {
+        Optional<VaxType> refVaxType = manager.remove(refName);
+
+        HashSet<String> grps = setGrps.orElse(refVaxType
+                .map(VaxType::getGroups)
+                .orElse(VaxType.DEFAULT_GROUP_SET));
+        Integer minAge = setMinAge.orElse(refVaxType
+                .map(VaxType::getMinAge)
+                .orElse(VaxType.DEFAULT_MIN_AGE));
+        Integer maxAge = setMaxAge.orElse(refVaxType
+                .map(VaxType::getMaxAge)
+                .orElse(VaxType.DEFAULT_MAX_AGE));
+        Integer minSpacing = setMinSpacing.orElse(refVaxType
+                .map(VaxType::getMinSpacing)
+                .orElse(VaxType.DEFAULT_MIN_SPACING));
+        List<Requirement> allergyReqs = setAllergyReqs.orElse(refVaxType
+                .map(VaxType::getAllergyReqs)
+                .orElse(VaxType.DEFAULT_ALLERGY_REQS));
+        List<Requirement> historyReqs = setHistoryReqs.orElse(refVaxType
+                .map(VaxType::getHistoryReqs)
+                .orElse(VaxType.DEFAULT_HISTORY_REQS));
+
+        VaxType vaxType = new VaxType(name, grps, minAge, maxAge, minSpacing, allergyReqs, historyReqs);
+        manager.add(vaxType);
         return vaxType;
     }
 }

--- a/src/main/java/seedu/vms/model/vaccination/VaxTypeBuilder.java
+++ b/src/main/java/seedu/vms/model/vaccination/VaxTypeBuilder.java
@@ -15,9 +15,8 @@ public class VaxTypeBuilder {
     private static final String MESSAGE_DUPLICATE_TYPE = "Vaccination type already exist";
     private static final String MESSAGE_MISSING_TYPE = "Vaccination type does not exist";
 
-    private final String refName;
-
-    private final String name;
+    private final VaxName refName;
+    private final VaxName name;
     private final Optional<HashSet<String>> setGrps;
     private final Optional<Integer> setMinAge;
     private final Optional<Integer> setMaxAge;
@@ -26,7 +25,7 @@ public class VaxTypeBuilder {
     private final Optional<List<Requirement>> setHistoryReqs;
 
 
-    private VaxTypeBuilder(String refName, String name, Optional<HashSet<String>> setGrps,
+    private VaxTypeBuilder(VaxName refName, VaxName name, Optional<HashSet<String>> setGrps,
                 Optional<Integer> setMinAge, Optional<Integer> setMaxAge, Optional<Integer> setMinSpacing,
                 Optional<List<Requirement>> setAllergyReqs, Optional<List<Requirement>> setHistoryReqs) {
         this.refName = refName;
@@ -47,7 +46,7 @@ public class VaxTypeBuilder {
      *      from.
      * @param name - the name of the {@code VaxType} to create.
      */
-    public static VaxTypeBuilder of(String refName, String name) {
+    public static VaxTypeBuilder of(VaxName refName, VaxName name) {
         return new VaxTypeBuilder(refName, name,
                 Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty());
@@ -59,12 +58,12 @@ public class VaxTypeBuilder {
      *
      * @param name - the name of the {@code VaxType} to create.
      */
-    public static VaxTypeBuilder of(String name) {
+    public static VaxTypeBuilder of(VaxName name) {
         return VaxTypeBuilder.of(name, name);
     }
 
 
-    public VaxTypeBuilder setName(String name) {
+    public VaxTypeBuilder setName(VaxName name) {
         return new VaxTypeBuilder(refName, name, setGrps,
                 setMinAge, setMaxAge, setMinSpacing,
                 setAllergyReqs, setHistoryReqs);
@@ -122,7 +121,7 @@ public class VaxTypeBuilder {
      *      replaced.
      */
     public VaxType create(VaxTypeManager manager) throws IllegalValueException {
-        if (manager.contains(refName) || manager.contains(name)) {
+        if (manager.contains(refName.toString()) || manager.contains(name.toString())) {
             throw new IllegalValueException(MESSAGE_DUPLICATE_TYPE);
         }
         return build(manager);
@@ -139,7 +138,8 @@ public class VaxTypeBuilder {
      *      already exists.
      */
     public VaxType update(VaxTypeManager manager) throws IllegalValueException {
-        if (!manager.contains(refName) || (!refName.equals(name) && manager.contains(name))) {
+        if (!manager.contains(refName.toString())
+                    || (!refName.equals(name) && manager.contains(name.toString()))) {
             throw new IllegalValueException(MESSAGE_MISSING_TYPE);
         }
         return build(manager);
@@ -147,7 +147,7 @@ public class VaxTypeBuilder {
 
 
     private VaxType build(VaxTypeManager manager) {
-        Optional<VaxType> refVaxType = manager.remove(refName);
+        Optional<VaxType> refVaxType = manager.remove(refName.toString());
 
         HashSet<String> grps = setGrps.orElse(refVaxType
                 .map(VaxType::getGroups)

--- a/src/main/java/seedu/vms/storage/vaccination/JsonAdaptedVaxType.java
+++ b/src/main/java/seedu/vms/storage/vaccination/JsonAdaptedVaxType.java
@@ -78,11 +78,11 @@ public class JsonAdaptedVaxType {
      *
      * @throws IllegalValueException if name field is missing.
      */
-    public VaxType toModelType(VaxTypeManager storage) throws IllegalValueException {
+    public VaxType toModelType(VaxTypeManager manager) throws IllegalValueException {
         if (name == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "NAME"));
         }
-        VaxTypeBuilder builder = VaxTypeBuilder.of(storage, name);
+        VaxTypeBuilder builder = VaxTypeBuilder.of(name);
 
         if (groups != null) {
             builder = builder.setGroups(new HashSet<>(groups));
@@ -108,7 +108,7 @@ public class JsonAdaptedVaxType {
             builder = builder.setHistoryReqs(toReqList(historyReqs));
         }
 
-        return builder.build();
+        return builder.create(manager);
     }
 
 

--- a/src/main/java/seedu/vms/storage/vaccination/JsonAdaptedVaxType.java
+++ b/src/main/java/seedu/vms/storage/vaccination/JsonAdaptedVaxType.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.vms.commons.exceptions.IllegalValueException;
 import seedu.vms.model.vaccination.Requirement;
+import seedu.vms.model.vaccination.VaxName;
 import seedu.vms.model.vaccination.VaxType;
 import seedu.vms.model.vaccination.VaxTypeBuilder;
 import seedu.vms.model.vaccination.VaxTypeManager;
@@ -19,7 +20,7 @@ import seedu.vms.model.vaccination.VaxTypeManager;
 public class JsonAdaptedVaxType {
     private static final String MISSING_FIELD_MESSAGE_FORMAT = "Vaccination type [%s] is missing";
 
-    private final String name;
+    private final VaxName name;
     private final List<String> groups;
     private final Integer minAge;
     private final Integer maxAge;
@@ -31,7 +32,7 @@ public class JsonAdaptedVaxType {
     /** Constructs a {@code JsonAdaptedVaxType}. */
     @JsonCreator
     public JsonAdaptedVaxType(
-                @JsonProperty("name") String name,
+                @JsonProperty("name") VaxName name,
                 @JsonProperty("groups") List<String> groups,
                 @JsonProperty("minAge") Integer minAge,
                 @JsonProperty("maxAge") Integer maxAge,
@@ -53,7 +54,7 @@ public class JsonAdaptedVaxType {
      * {@code JsonAdaptedVaxType}.
      */
     public static JsonAdaptedVaxType fromModelType(VaxType vaxType) {
-        String name = vaxType.getName();
+        VaxName name = new VaxName(vaxType.getName());
         List<String> groups = List.copyOf(vaxType.getGroups());
         Integer minAge = vaxType.getMinAge();
         Integer maxAge = vaxType.getMaxAge();

--- a/src/test/java/seedu/vms/logic/commands/patient/AddCommandTest.java
+++ b/src/test/java/seedu/vms/logic/commands/patient/AddCommandTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableMap;
 import seedu.vms.commons.core.GuiSettings;
+import seedu.vms.commons.exceptions.IllegalValueException;
 import seedu.vms.logic.commands.CommandResult;
 import seedu.vms.model.IdData;
 import seedu.vms.model.Model;
@@ -23,6 +24,7 @@ import seedu.vms.model.patient.AddressBook;
 import seedu.vms.model.patient.Patient;
 import seedu.vms.model.patient.ReadOnlyAddressBook;
 import seedu.vms.model.vaccination.VaxType;
+import seedu.vms.model.vaccination.VaxTypeAction;
 import seedu.vms.model.vaccination.VaxTypeManager;
 import seedu.vms.testutil.PatientBuilder;
 
@@ -149,6 +151,11 @@ public class AddCommandTest {
 
         @Override
         public VaxTypeManager getVaxTypeManager() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public VaxType performVaxTypeAction(VaxTypeAction action) throws IllegalValueException {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/vms/model/vaccination/VaxNameTest.java
+++ b/src/test/java/seedu/vms/model/vaccination/VaxNameTest.java
@@ -40,9 +40,11 @@ public class VaxNameTest {
         VaxName testing = new VaxName(SAMPLE_NAME);
         VaxName eqs = new VaxName(SAMPLE_NAME + " ");
         VaxName diff = new VaxName(SAMPLE_NAME + "a");
+        Integer unrelated = Integer.valueOf(0);
 
         assertTrue(testing.equals(testing));
         assertTrue(testing.equals(eqs));
         assertFalse(testing.equals(diff));
+        assertFalse(testing.equals(unrelated));
     }
 }

--- a/src/test/java/seedu/vms/model/vaccination/VaxNameTest.java
+++ b/src/test/java/seedu/vms/model/vaccination/VaxNameTest.java
@@ -1,0 +1,34 @@
+package seedu.vms.model.vaccination;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+public class VaxNameTest {
+    private static List<String> INVALID_LIST = List.of(
+        "",
+        " ",
+        "a\n\ra",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "abc:",
+        "( ^)o(^ )b");
+
+
+    @Test
+    public void isValidName_valid_true() {
+        assertTrue(VaxName.isValidName(
+            "   120 - []{}()- Pks niUw LK <> k    "));
+        assertTrue(VaxName.isValidName("a"));
+    }
+
+
+    @Test
+    public void isValidName_invalid_false() {
+        for (String invalid : INVALID_LIST) {
+            assertFalse(VaxName.isValidName(invalid), invalid);
+        }
+    }
+}

--- a/src/test/java/seedu/vms/model/vaccination/VaxNameTest.java
+++ b/src/test/java/seedu/vms/model/vaccination/VaxNameTest.java
@@ -16,6 +16,8 @@ public class VaxNameTest {
         "abc:",
         "( ^)o(^ )b");
 
+    private static final String SAMPLE_NAME = "UNCHI";
+
 
     @Test
     public void isValidName_valid_true() {
@@ -30,5 +32,17 @@ public class VaxNameTest {
         for (String invalid : INVALID_LIST) {
             assertFalse(VaxName.isValidName(invalid), invalid);
         }
+    }
+
+
+    @Test
+    public void equalsTest() {
+        VaxName testing = new VaxName(SAMPLE_NAME);
+        VaxName eqs = new VaxName(SAMPLE_NAME + " ");
+        VaxName diff = new VaxName(SAMPLE_NAME + "a");
+
+        assertTrue(testing.equals(testing));
+        assertTrue(testing.equals(eqs));
+        assertFalse(testing.equals(diff));
     }
 }

--- a/src/test/java/seedu/vms/model/vaccination/VaxRecordKeyTest.java
+++ b/src/test/java/seedu/vms/model/vaccination/VaxRecordKeyTest.java
@@ -11,7 +11,7 @@ import java.util.HashSet;
 import org.junit.jupiter.api.Test;
 
 public class VaxRecordKeyTest {
-    private static final String SAMPLE_NAME = "UNCHI";
+    private static final VaxName SAMPLE_NAME = new VaxName("UNCHI");
     private static final LocalDateTime SAMPLE_TIME = LocalDateTime.now();
     private static final VaxRecordKey SAMPLE_RECORD = new VaxRecordKey(SAMPLE_NAME, SAMPLE_TIME);
 
@@ -21,13 +21,13 @@ public class VaxRecordKeyTest {
         assertThrows(NullPointerException.class,
                 () -> new VaxRecordKey(null, LocalDateTime.now()));
         assertThrows(NullPointerException.class,
-                () -> new VaxRecordKey("abc", null));
+                () -> new VaxRecordKey(SAMPLE_NAME, null));
     }
 
 
     @Test
     public void getVaccination() {
-        assertEquals(SAMPLE_NAME, SAMPLE_RECORD.getVaxTypeKey());
+        assertEquals(SAMPLE_NAME.toString(), SAMPLE_RECORD.getVaxTypeKey());
     }
 
 
@@ -41,7 +41,7 @@ public class VaxRecordKeyTest {
     public void equals() {
         Object eqs = new VaxRecordKey(SAMPLE_NAME, SAMPLE_TIME);
         Object diff1 = new VaxRecordKey(SAMPLE_NAME, LocalDateTime.MIN);
-        Object diff2 = new VaxRecordKey("BANANA", SAMPLE_TIME);
+        Object diff2 = new VaxRecordKey(new VaxName("BANANA"), SAMPLE_TIME);
         Object unrelated = Integer.valueOf(445);
 
         assertTrue(SAMPLE_RECORD.equals(SAMPLE_RECORD));
@@ -56,7 +56,7 @@ public class VaxRecordKeyTest {
     public void hashingTest() {
         VaxRecordKey rec1 = SAMPLE_RECORD;
         VaxRecordKey recEq = new VaxRecordKey(SAMPLE_NAME, SAMPLE_TIME);
-        VaxRecordKey recDiff = new VaxRecordKey("BANANA", SAMPLE_TIME);
+        VaxRecordKey recDiff = new VaxRecordKey(new VaxName("BANANA"), SAMPLE_TIME);
 
         HashSet<VaxRecordKey> recSet = new HashSet<>();
         recSet.add(rec1);


### PR DESCRIPTION
### Issues resolved
* Resolves #93

### Significant changes

* Add `VaxName` class to validate vaccination names.
* Basic command to add vaccination types added.

### Testing

#### `VaxName` class

Automated tests created.

#### Add command

Manual testing of the following commands

1. `unchi` added.
```
vaccination add unchi
```
2. Error message shown (duplicate)
```
vaccination add unchi
```
3. Error message shown (invalid characters)
```
vaccination add unchi:
```

### Additional stuff

@francisyzy I am so sorry for adding this so late but I think patient should store this `VaxName` class. But we can integrate this later.