### PR TITLE
Fix ID numbering

### DIFF
--- a/src/main/java/seedu/vms/commons/exceptions/LimitExceededException.java
+++ b/src/main/java/seedu/vms/commons/exceptions/LimitExceededException.java
@@ -1,0 +1,41 @@
+package seedu.vms.commons.exceptions;
+
+
+/** Signals that a limit has been exceeded. */
+public class LimitExceededException extends RuntimeException {
+    /**
+     * Constructs an {@code LimitExceededException} without a message or cause.
+     */
+    public LimitExceededException() {}
+
+
+    /**
+     * Constructs an {@code LimitExceededException} without a cause.
+     *
+     * @param message - message of the exception.
+     */
+    public LimitExceededException(String message) {
+        super(message);
+    }
+
+
+    /**
+     * Constructs an {@code LimitExceededException} without a cause.
+     *
+     * @param cause - the cause of the exception.
+     */
+    public LimitExceededException(Throwable cause) {
+        super(cause);
+    }
+
+
+    /**
+     * Constructs an {@code LimitExceededException}.
+     *
+     * @param message - the message of the exception.
+     * @param cause - the cause of the exception.
+     */
+    public LimitExceededException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/seedu/vms/model/IdDataMap.java
+++ b/src/main/java/seedu/vms/model/IdDataMap.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableMap;
+import seedu.vms.commons.exceptions.LimitExceededException;
 
 
 /**
@@ -16,16 +17,30 @@ import javafx.collections.ObservableMap;
  * @param <T> - type of data stored.
  */
 public class IdDataMap<T> {
+    public static final int DEFAULT_LIMIT = 1000;
+
     private static final int STARTING_INDEX = 0;
 
+    private final int limit;
     private final ObservableMap<Integer, IdData<T>> internalMap;
     private final ObservableMap<Integer, IdData<T>> internalUnmodifiableMap;
 
     private int nextId = STARTING_INDEX;
 
 
-    /** Constructs an empty {@code IdDataMap}. */
+    /** Constructs an empty {@code IdDataMap} that uses the default limit. */
     public IdDataMap() {
+        this(DEFAULT_LIMIT);
+    }
+
+
+    /**
+     * Constructs an empty {@code IdDataMap}.
+     *
+     * @param limit - the size limit of this data map.
+     */
+    public IdDataMap(int limit) {
+        this.limit = limit;
         internalMap = FXCollections.observableHashMap();
         internalUnmodifiableMap = FXCollections.unmodifiableObservableMap(internalMap);
     }
@@ -35,12 +50,13 @@ public class IdDataMap<T> {
      * Adds the value to the map.
      *
      * @param value - the value to add.
+     * @throws LimitExceededException if the number of data has reached its
+     *      limit.
      */
-    public void add(T value) {
+    public void add(T value) throws LimitExceededException {
         Objects.requireNonNull(value);
-        IdData<T> data = new IdData<>(nextId, value);
+        IdData<T> data = new IdData<>(getNextId(), value);
         add(data);
-        nextId++;
     }
 
 
@@ -50,9 +66,13 @@ public class IdDataMap<T> {
      *
      * @param data - the data to add.
      */
-    public void add(IdData<T> data) {
+    public void add(IdData<T> data) throws LimitExceededException {
         Objects.requireNonNull(data);
+        if (!isValidId(data.getId())) {
+            throw new LimitExceededException();
+        }
         internalMap.put(data.getId(), data);
+        nextId = Math.max(nextId, data.getId());
     }
 
 
@@ -82,10 +102,6 @@ public class IdDataMap<T> {
      * @throws NoSuchElementException if the ID is not present.
      */
     public IdData<T> remove(int id) {
-        if (!internalMap.containsKey(id)) {
-            // TODO: this exception is unhandled by utilising methods.
-            throw new NoSuchElementException(String.format("ID [%d] not found", id));
-        }
         return internalMap.remove(id);
     }
 
@@ -97,7 +113,7 @@ public class IdDataMap<T> {
      * @return {@code true} if a mapping is present to the ID and {@code false}
      *      otherwise.
      */
-    public boolean containts(int id) {
+    public boolean contains(int id) {
         return internalMap.containsKey(id);
     }
 
@@ -112,11 +128,7 @@ public class IdDataMap<T> {
         internalMap.clear();
         nextId = STARTING_INDEX;
         for (IdData<T> data : datas) {
-            int id = data.getId();
-            if (id >= nextId) {
-                nextId = id + 1;
-            }
-            internalMap.put(id, data);
+            add(data);
         }
     }
 
@@ -144,5 +156,24 @@ public class IdDataMap<T> {
      */
     public ObservableMap<Integer, IdData<T>> asUnmodifiableObservableMap() {
         return internalUnmodifiableMap;
+    }
+
+
+    private int getNextId() throws LimitExceededException {
+        if (internalMap.size() >= limit) {
+            throw new LimitExceededException();
+        }
+        while (contains(nextId)) {
+            nextId++;
+            if (!isValidId(nextId)) {
+                nextId = 0;
+            }
+        }
+        return nextId;
+    }
+
+
+    private boolean isValidId(int id) {
+        return 0 <= id && id < limit;
     }
 }

--- a/src/main/java/seedu/vms/model/IdDataMap.java
+++ b/src/main/java/seedu/vms/model/IdDataMap.java
@@ -149,6 +149,11 @@ public class IdDataMap<T> {
     }
 
 
+    public IdData<T> get(int id) {
+        return internalMap.get(id);
+    }
+
+
     /**
      * Returns an unmodifiable map view of this data map.
      *

--- a/src/main/java/seedu/vms/model/StorageModel.java
+++ b/src/main/java/seedu/vms/model/StorageModel.java
@@ -73,7 +73,7 @@ public abstract class StorageModel<T> implements ReadOnlyStorageModel<T> {
      *      {@code false} otherwise.
      */
     public boolean contains(int id) {
-        return dataMap.containts(id);
+        return dataMap.contains(id);
     }
 
 

--- a/src/main/java/seedu/vms/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/vms/storage/JsonSerializableAddressBook.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 import seedu.vms.commons.exceptions.IllegalValueException;
+import seedu.vms.commons.exceptions.LimitExceededException;
 import seedu.vms.model.IdData;
 import seedu.vms.model.patient.AddressBook;
 import seedu.vms.model.patient.Patient;
@@ -57,7 +58,12 @@ class JsonSerializableAddressBook {
             if (addressBook.contains(patientData.getId())) {
                 throw new IllegalValueException(DUPLICATE_ID);
             }
-            addressBook.add(patientData);
+            try {
+                addressBook.add(patientData);
+            } catch (LimitExceededException limitEx) {
+                // TODO: better message
+                throw new IllegalValueException("ID limit reached");
+            }
         }
         return addressBook;
     }

--- a/src/test/java/seedu/vms/model/IdDataMapTest.java
+++ b/src/test/java/seedu/vms/model/IdDataMapTest.java
@@ -1,0 +1,159 @@
+package seedu.vms.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.vms.commons.exceptions.LimitExceededException;
+
+public class IdDataMapTest {
+    private static final int TESTING_LIMIT = 10;
+
+    private static final List<Integer> RANDOM_VALUES = List.of(5, 6, 0, 7, 8, 9, 1, 3, 4, 2);
+
+    private IdDataMap<Integer> idMap;
+
+
+    @BeforeEach
+    public void initializeIdMap() {
+        idMap = new IdDataMap<>(TESTING_LIMIT);
+    }
+
+
+    @Test
+    public void add_valueWithinLimit_valueAdded() {
+        for (int i = 0; i < TESTING_LIMIT; i++) {
+            idMap.add(i);
+        }
+        for (int i = 0; i < TESTING_LIMIT; i++) {
+            assertTrue(idMap.contains(i));
+        }
+    }
+
+
+    @Test
+    public void add_valueOverLimit_exceptionThrown() {
+        for (int i = 0; i < TESTING_LIMIT; i++) {
+            idMap.add(i);
+        }
+        assertThrows(LimitExceededException.class,
+                () -> idMap.add(TESTING_LIMIT));
+    }
+
+
+    @Test
+    public void add_dataWithinLimit_valueAdded() {
+        for (int i = 0; i < TESTING_LIMIT; i++) {
+            idMap.add(new IdData<>(true, i, i));
+        }
+        for (int i = 0; i < TESTING_LIMIT; i++) {
+            assertTrue(idMap.contains(i));
+        }
+    }
+
+
+    @Test
+    public void add_dataOverLimit_exceptionThrown() {
+        assertThrows(LimitExceededException.class,
+                () -> idMap.add(new IdData<>(true, -1, -1)));
+        assertThrows(LimitExceededException.class,
+                () -> idMap.add(new IdData<>(true, TESTING_LIMIT, TESTING_LIMIT)));
+    }
+
+
+    @Test
+    public void add_mixedUnordered() {
+        /* 0 */ idMap.add(new IdData<>(true, RANDOM_VALUES.get(0), RANDOM_VALUES.get(0)));
+        /* 1 */ idMap.add(RANDOM_VALUES.get(1));
+        /* 2 */ idMap.add(new IdData<>(true, RANDOM_VALUES.get(2), RANDOM_VALUES.get(2)));
+        /* 3 */ idMap.add(RANDOM_VALUES.get(3));
+        /* 4 */ idMap.add(RANDOM_VALUES.get(4));
+        /* 5 */ idMap.add(RANDOM_VALUES.get(5));
+        /* 6 */ idMap.add(RANDOM_VALUES.get(6));
+        /* 7 */ idMap.add(new IdData<>(true, RANDOM_VALUES.get(7), RANDOM_VALUES.get(7)));
+        /* 8 */ idMap.add(RANDOM_VALUES.get(8));
+        /* 9 */ idMap.add(RANDOM_VALUES.get(9));
+        for (int i = 0; i < TESTING_LIMIT; i++) {
+            assertEquals(i, idMap.get(i).getValue());
+        }
+
+        // limit
+        assertThrows(LimitExceededException.class,
+                () -> idMap.add(new IdData<>(true, TESTING_LIMIT, TESTING_LIMIT)));
+    }
+
+
+    @Test
+    public void setValues_withinLimit_valuesAdded() {
+        ArrayList<Integer> values = new ArrayList<>();
+        for (int i = 0; i < TESTING_LIMIT; i++) {
+            values.add(i);
+        }
+        idMap.setValues(values);
+        for (int i = 0; i < TESTING_LIMIT; i++) {
+            assertEquals(i, idMap.get(i).getValue());
+        }
+    }
+
+
+    @Test
+    public void setValues_overLimit_exceptionThrown() {
+        ArrayList<Integer> values = new ArrayList<>();
+        for (int i = 0; i < TESTING_LIMIT + 1; i++) {
+            values.add(i);
+        }
+        assertThrows(LimitExceededException.class, () -> idMap.setValues(values));
+    }
+
+
+    @Test
+    public void setDatas_withinLimit_valuesAdded() {
+        ArrayList<IdData<Integer>> datas = formRandDataList();
+        idMap.setDatas(datas);
+        for (int i = 0; i < TESTING_LIMIT; i++) {
+            assertEquals(i, idMap.get(i).getValue());
+        }
+    }
+
+
+    @Test
+    public void setDatas_overLimit_exceptionThrown() {
+        List<Integer> idValues = List.of(-1, TESTING_LIMIT);
+        for (Integer id : idValues) {
+            for (int i = 0; i < TESTING_LIMIT; i++) {
+                ArrayList<IdData<Integer>> datas = formRandDataList();
+                datas.remove(i);
+                datas.add(i, new IdData<>(true, id, id));
+                assertThrows(LimitExceededException.class, () -> idMap.setDatas(datas));
+            }
+        }
+    }
+
+
+    @Test
+    public void set() {
+        int initial = 0;
+        int change = 1;
+        idMap.add(initial);
+        idMap.set(0, change);
+        assertEquals(change, idMap.get(0).getValue());
+
+        assertThrows(NoSuchElementException.class, () -> idMap.set(1, change));
+    }
+
+
+    private ArrayList<IdData<Integer>> formRandDataList() {
+        ArrayList<IdData<Integer>> datas = new ArrayList<>();
+        for (int i = 0; i < TESTING_LIMIT; i++) {
+            datas.add(new IdData<Integer>(true, RANDOM_VALUES.get(i), RANDOM_VALUES.get(i)));
+        }
+        return datas;
+    }
+}


### PR DESCRIPTION
### Issues resolved
* Resolves #67 

### Significant changes

* Add limit to ID map (default is 1000 but can be customised)
* Add looping functionalities for IDs.
* `IdDataMap` will now throw an `LimitExceededException` limit is exceeded during additon. Exception is an extension of `RuntimeException`. No error will be shown if this exception is not handled but there should at least be `try` and `catch` block is commands that add to `IdDataMap`.

### Testing

Automated tests created. I believe it covers all paths.