### PR TITLE
Fix `LogicManager` breaking on unexpected exceptions

### DIFF
--- a/src/main/java/seedu/vms/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/vms/logic/commands/CommandResult.java
@@ -103,6 +103,6 @@ public class CommandResult {
      * Represents the state of a {@code CommandResult}.
      */
     public static enum State {
-        INFO, WARNING, ERROR
+        INFO, WARNING, ERROR, DEATH
     }
 }

--- a/src/main/java/seedu/vms/ui/ResultMessageBox.java
+++ b/src/main/java/seedu/vms/ui/ResultMessageBox.java
@@ -10,6 +10,7 @@ import seedu.vms.logic.commands.CommandResult;
 public class ResultMessageBox extends UiPart<Region> {
     private static final String FXML_FILE = "ResultMessageBox.fxml";
 
+    private static final String STYLE_CLASS_DEATH = "result-message-death-color";
     private static final String STYLE_CLASS_ERROR = "result-message-error-color";
     private static final String STYLE_CLASS_WARNING = "result-message-warning-color";
     private static final String STYLE_CLASS_INFO = "result-message-info-color";
@@ -34,6 +35,10 @@ public class ResultMessageBox extends UiPart<Region> {
 
         case WARNING:
             colorStyleClass = STYLE_CLASS_WARNING;
+            break;
+
+        case DEATH:
+            colorStyleClass = STYLE_CLASS_DEATH;
             break;
 
         default:

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -102,6 +102,10 @@
   -fx-background-color: -fx-control-inner-background;
 }
 
+.result-message-death-color {
+  -fx-text-fill: #7721d2;
+}
+
 .result-message-error-color {
   -fx-text-fill: #d22121;
 }


### PR DESCRIPTION
`LogicManager` will now catch all exceptions while executing a command.

If the exception thrown is not what it expects, ie `ParseException` or `CommandException`, it will produce a `DEATH` state `CommandResult`. The color is set to purple for now which can be changed later.

### Testing

`ModelManager` requires 1000 stubs to be created. So to test it, I manually changed a command to always throw an exception to see if `LogicManager` breaks. I changed it back after testing.

Here is the result in the result box after entering the edited command and patient add to see if `LogicManager` is still working:
![image](https://user-images.githubusercontent.com/100074448/224921333-10d5979e-c68f-4f30-8e24-773c2740d4ca.png)

### Additional Stuff

We should never see the purple text. The state is name `DEATH` as I do not have any other better names but please feel free to change it if there is a more appropriate name.

### Issues addressed

* Fixes #166 