### PR TITLE
Update CI to not run on draft PRs

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,10 +15,9 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
+    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
 
     steps:
-      - if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
-
       - name: Set up repository
         uses: actions/checkout@main
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,8 +2,6 @@ name: Java CI
 
 on:
   push:
-    branches:
-      - master
   pull_request:
     types:
       - opened

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,6 +1,15 @@
 name: Java CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 jobs:
   build:
@@ -10,6 +19,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
+        if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+
       - name: Set up repository
         uses: actions/checkout@main
 
@@ -23,7 +34,7 @@ jobs:
 
       - name: Run repository-wide tests
         if: runner.os == 'Linux'
-        working-directory:  ${{ github.workspace }}/.github
+        working-directory: ${{ github.workspace }}/.github
         run: ./run-checks.sh
 
       - name: Validate Gradle Wrapper

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-        if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+      - if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
 
       - name: Set up repository
         uses: actions/checkout@main


### PR DESCRIPTION
Do see the following links on where the solution was gathered from.

This change allows the PR to stop having red X everywhere when it is not ready for review yet. PR drafts allow for team members to catch up on what is being worked on. So that we can be updated on what is happening.

https://gist.github.com/myobie/671d2f2a1e503efa0c05e7b865c26a9d

https://github.com/orgs/community/discussions/25722#discussioncomment-3248917