### PR TITLE
Move (partial) VmsParser to model

### DIFF
--- a/src/main/java/seedu/vms/logic/LogicManager.java
+++ b/src/main/java/seedu/vms/logic/LogicManager.java
@@ -15,7 +15,6 @@ import seedu.vms.commons.core.LogsCenter;
 import seedu.vms.logic.commands.Command;
 import seedu.vms.logic.commands.exceptions.CommandException;
 import seedu.vms.logic.parser.ParseResult;
-import seedu.vms.logic.parser.VmsParser;
 import seedu.vms.logic.parser.exceptions.ParseException;
 import seedu.vms.model.IdData;
 import seedu.vms.model.Model;
@@ -34,7 +33,6 @@ public class LogicManager implements Logic {
 
     private final Model model;
     private final Storage storage;
-    private final VmsParser vmsParser;
 
     private Consumer<List<CommandMessage>> onExecutionComplete = results -> {};
 
@@ -47,7 +45,6 @@ public class LogicManager implements Logic {
     public LogicManager(Model model, Storage storage) {
         this.model = model;
         this.storage = storage;
-        vmsParser = new VmsParser();
     }
 
 
@@ -82,7 +79,7 @@ public class LogicManager implements Logic {
     private void parseCommand(String commandText) {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
         try {
-            execute(vmsParser.parseCommand(commandText));
+            execute(model.parseCommand(commandText));
         } catch (ParseException parseEx) {
             completeExecution(List.of(new CommandMessage(
                     parseEx.getMessage(),

--- a/src/main/java/seedu/vms/model/Model.java
+++ b/src/main/java/seedu/vms/model/Model.java
@@ -6,6 +6,8 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableMap;
 import seedu.vms.commons.core.GuiSettings;
 import seedu.vms.commons.exceptions.IllegalValueException;
+import seedu.vms.logic.parser.ParseResult;
+import seedu.vms.logic.parser.exceptions.ParseException;
 import seedu.vms.model.appointment.Appointment;
 import seedu.vms.model.appointment.AppointmentManager;
 import seedu.vms.model.patient.Patient;
@@ -138,4 +140,15 @@ public interface Model {
     VaxType performVaxTypeAction(VaxTypeAction action) throws IllegalValueException;
 
     VaxType deleteVaxType(GroupName vaxName) throws IllegalValueException;
+
+
+    /**
+     * Parses the specified user command.
+     *
+     * @param userCommand - the user command to parse.
+     * @return the {@code ParseResult} that results from the parsed user
+     *      command.
+     * @throws ParseException if the user command cannot be parsed.
+     */
+    ParseResult parseCommand(String userCommand) throws ParseException;
 }

--- a/src/main/java/seedu/vms/model/ModelManager.java
+++ b/src/main/java/seedu/vms/model/ModelManager.java
@@ -11,6 +11,9 @@ import javafx.collections.ObservableMap;
 import seedu.vms.commons.core.GuiSettings;
 import seedu.vms.commons.core.LogsCenter;
 import seedu.vms.commons.exceptions.IllegalValueException;
+import seedu.vms.logic.parser.ParseResult;
+import seedu.vms.logic.parser.VmsParser;
+import seedu.vms.logic.parser.exceptions.ParseException;
 import seedu.vms.model.appointment.Appointment;
 import seedu.vms.model.appointment.AppointmentManager;
 import seedu.vms.model.patient.Patient;
@@ -99,6 +102,14 @@ public class ModelManager implements Model {
     public void setPatientManagerFilePath(Path patientManagerFilePath) {
         requireNonNull(patientManagerFilePath);
         userPrefs.setPatientManagerFilePath(patientManagerFilePath);
+    }
+
+    // =========== Parsing =======================================================================================
+
+    @Override
+    public ParseResult parseCommand(String userCommand) throws ParseException {
+        // TODO: Avoid creating a new parser everytime
+        return new VmsParser().parseCommand(userCommand);
     }
 
     // =========== PatientManager ================================================================================

--- a/src/test/java/seedu/vms/logic/commands/patient/AddCommandTest.java
+++ b/src/test/java/seedu/vms/logic/commands/patient/AddCommandTest.java
@@ -17,6 +17,8 @@ import javafx.collections.ObservableMap;
 import seedu.vms.commons.core.GuiSettings;
 import seedu.vms.commons.exceptions.IllegalValueException;
 import seedu.vms.logic.CommandMessage;
+import seedu.vms.logic.parser.ParseResult;
+import seedu.vms.logic.parser.exceptions.ParseException;
 import seedu.vms.model.GroupName;
 import seedu.vms.model.IdData;
 import seedu.vms.model.Model;
@@ -198,6 +200,12 @@ public class AddCommandTest {
         public VaxType deleteVaxType(GroupName vaxName) throws IllegalValueException {
             // TODO Auto-generated method stub
             throw new UnsupportedOperationException("Unimplemented method 'deleteVaxType'");
+        }
+
+        @Override
+        public ParseResult parseCommand(String userCommand) throws ParseException {
+            // TODO Auto-generated method stub
+            throw new UnsupportedOperationException("Unimplemented method 'parseCommand'");
         }
     }
 

--- a/src/test/java/seedu/vms/logic/commands/vaccination/VaxTypeModelStub.java
+++ b/src/test/java/seedu/vms/logic/commands/vaccination/VaxTypeModelStub.java
@@ -6,6 +6,8 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableMap;
 import seedu.vms.commons.core.GuiSettings;
 import seedu.vms.commons.exceptions.IllegalValueException;
+import seedu.vms.logic.parser.ParseResult;
+import seedu.vms.logic.parser.exceptions.ParseException;
 import seedu.vms.model.GroupName;
 import seedu.vms.model.IdData;
 import seedu.vms.model.Model;
@@ -149,6 +151,12 @@ public class VaxTypeModelStub implements Model {
         return manager.remove(vaxName.toString())
                 .orElseThrow(() -> new IllegalValueException(String.format(
                         "Vaccination type does not exist: %s", vaxName.toString())));
+    }
+
+    @Override
+    public ParseResult parseCommand(String userCommand) throws ParseException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'parseCommand'");
     }
 
 }


### PR DESCRIPTION
`LogicManager` in this implementation will use `Model` `VmsParser` instead of its own.

`VmsParser` is not yet moved into `Model`. Currently only the method to parse a command is implemented (`Model#parseCommand(String)`). In the method, a new `VmsParser` is created everytime it is called to implement the skeleton which should be changed in future iterations.

### Testing

Regression testing - nothing broke.

### Issues addressed

* Touches on #215 