### PR TITLE
Fix copy and paste in message box

### DIFF
--- a/src/main/java/seedu/vms/ui/ResultMessageBox.java
+++ b/src/main/java/seedu/vms/ui/ResultMessageBox.java
@@ -1,8 +1,11 @@
 package seedu.vms.ui;
 
+import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
+import javafx.scene.control.TextArea;
 import javafx.scene.layout.Region;
+import javafx.scene.text.Text;
 import seedu.vms.logic.CommandMessage;
 
 
@@ -16,7 +19,7 @@ public class ResultMessageBox extends UiPart<Region> {
     private static final String STYLE_CLASS_INFO = "result-message-info-color";
 
     @FXML private Label stateLabel;
-    @FXML private Label messageLabel;
+    @FXML private TextArea messageArea;
 
 
     /**
@@ -24,10 +27,36 @@ public class ResultMessageBox extends UiPart<Region> {
      */
     public ResultMessageBox(CommandMessage result) {
         super(FXML_FILE);
-        stateLabel.setText(String.format("[%s]", result.getState().toString()));
-        messageLabel.setText(result.getMessage());
+        setStateLabel(result.getState().toString());
+        setMessage(result.getMessage());
+        setStyle(result.getState());
+    }
+
+
+    private void setStateLabel(String state) {
+        stateLabel.setText(String.format("[%s]", state));
+    }
+
+
+    private void setMessage(String message) {
+        // listener block adapted from https://stackoverflow.com/a/25643696
+        messageArea.textProperty().addListener((ob, oldText, newText) -> {
+            Platform.runLater(() -> {
+                Text text = new Text(newText);
+                text.setFont(messageArea.getFont());
+                double height = text.getLayoutBounds().getHeight()
+                        + messageArea.getPadding().getTop() + messageArea.getPadding().getBottom()
+                        + 16D;
+                messageArea.setPrefHeight(height);
+            });
+        });
+        messageArea.setText(message);
+    }
+
+
+    private void setStyle(CommandMessage.State state) {
         String colorStyleClass;
-        switch (result.getState()) {
+        switch (state) {
 
         case ERROR:
             colorStyleClass = STYLE_CLASS_ERROR;
@@ -47,6 +76,6 @@ public class ResultMessageBox extends UiPart<Region> {
 
         }
         stateLabel.getStyleClass().add(colorStyleClass);
-        messageLabel.getStyleClass().add(colorStyleClass);
+        messageArea.getStyleClass().add(colorStyleClass);
     }
 }

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -102,6 +102,13 @@
   -fx-background-color: -fx-control-inner-background;
 }
 
+.result-message-box,
+.result-message-box .scroll-pane,
+.result-message-box .scroll-pane .content {
+  -fx-background-color: transparent;
+  -fx-border-color: transparent;
+}
+
 .result-message-death-color {
   -fx-text-fill: #7721d2;
 }

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -107,6 +107,7 @@
 .result-message-box .scroll-pane .content {
   -fx-background-color: transparent;
   -fx-border-color: transparent;
+  -fx-font-size: 11;
 }
 
 .result-message-death-color {

--- a/src/main/resources/view/ResultMessageBox.fxml
+++ b/src/main/resources/view/ResultMessageBox.fxml
@@ -1,19 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
+<?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.HBox?>
-
 
 <HBox maxHeight="-Infinity" minHeight="-Infinity" xmlns="http://javafx.com/javafx/null" xmlns:fx="http://javafx.com/fxml/1">
    <children>
       <HBox maxWidth="-Infinity" minWidth="-Infinity" prefWidth="70.0" HBox.hgrow="NEVER">
          <children>
-            <Label fx:id="stateLabel" HBox.hgrow="SOMETIMES" />
+            <Label fx:id="stateLabel" HBox.hgrow="SOMETIMES">
+               <padding>
+                  <Insets top="5.0" />
+               </padding></Label>
          </children>
       </HBox>
       <HBox HBox.hgrow="ALWAYS">
          <children>
-            <Label fx:id="messageLabel" wrapText="true" />
+            <TextArea fx:id="messageArea" editable="false" maxHeight="-Infinity" minHeight="-Infinity" styleClass="result-message-box" wrapText="true" HBox.hgrow="ALWAYS" />
          </children>
       </HBox>
    </children>


### PR DESCRIPTION
The message container of the command message message is change from a `Label` to a `TextArea` which allows text selection.

![image](https://user-images.githubusercontent.com/100074448/227003381-fe217921-f7b4-4845-a721-1454085fa5d7.png)

### Issues addressed

* Fixes #225 