### PR TITLE
Cascade delete skeleton

### DIFF
--- a/src/main/java/seedu/vms/commons/core/ValueChange.java
+++ b/src/main/java/seedu/vms/commons/core/ValueChange.java
@@ -1,31 +1,16 @@
 package seedu.vms.commons.core;
 
-import java.util.Objects;
 import java.util.Optional;
 
 
 /**
- * Represents a change in state of a value. A change will always contain an
- * {@code oldValue} but may not contain a {@code newValue}. If it does not
- * have a {@code newValue}, ie if {@link #getNewValue()} returns
- * {@code Optional.empty}, it signifies that the change is a deletion.
+ * Represents a change in state of a value.
  *
  * @param <T> the type of value being changed.
  */
 public class ValueChange<T> {
-    private final T oldValue;
+    private final Optional<T> oldValue;
     private final Optional<T> newValue;
-
-
-    /**
-     * Constructs a {@code ValueChange} without a new value.
-     *
-     * @param oldValue - the initial state of the value.
-     * @throws NullPointerException if {@code oldValue} is {@code null}.
-     */
-    public ValueChange(T oldValue) {
-        this(oldValue, null);
-    }
 
 
     /**
@@ -33,20 +18,22 @@ public class ValueChange<T> {
      *
      * @param oldValue - the initial state of the value.
      * @param newValue - the new state of the value (can be {@code null}).
-     * @throws NullPointerException if {@code oldValue} is {@code null}.
      */
     public ValueChange(T oldValue, T newValue) {
-        this.oldValue = Objects.requireNonNull(oldValue);
+        this.oldValue = Optional.ofNullable(oldValue);
         this.newValue = Optional.ofNullable(newValue);
     }
 
 
     /**
-     * Returns the initial state of the value being changed.
+     * Returns the old value wrapped in an {@code Optional}. If the change is
+     * only an addition, the change will not contain an old value and
+     * {@code Optional.empty} will be returned instead.
      *
-     * @return the initial state of the value being changed.
+     * @return the initial state of the value being changed wrapped in an
+     *      {@code Optional}.
      */
-    public T getOldValue() {
+    public Optional<T> getOldValue() {
         return oldValue;
     }
 

--- a/src/main/java/seedu/vms/commons/core/ValueChange.java
+++ b/src/main/java/seedu/vms/commons/core/ValueChange.java
@@ -1,0 +1,64 @@
+package seedu.vms.commons.core;
+
+import java.util.Objects;
+import java.util.Optional;
+
+
+/**
+ * Represents a change in state of a value. A change will always contain an
+ * {@code oldValue} but may not contain a {@code newValue}. If it does not
+ * have a {@code newValue}, ie if {@link #getNewValue()} returns
+ * {@code Optional.empty}, it signifies that the change is a deletion.
+ *
+ * @param <T> the type of value being changed.
+ */
+public class ValueChange<T> {
+    private final T oldValue;
+    private final Optional<T> newValue;
+
+
+    /**
+     * Constructs a {@code ValueChange} without a new value.
+     *
+     * @param oldValue - the initial state of the value.
+     * @throws NullPointerException if {@code oldValue} is {@code null}.
+     */
+    public ValueChange(T oldValue) {
+        this(oldValue, null);
+    }
+
+
+    /**
+     * Constructs a {@code ValueChange}.
+     *
+     * @param oldValue - the initial state of the value.
+     * @param newValue - the new state of the value (can be {@code null}).
+     * @throws NullPointerException if {@code oldValue} is {@code null}.
+     */
+    public ValueChange(T oldValue, T newValue) {
+        this.oldValue = Objects.requireNonNull(oldValue);
+        this.newValue = Optional.ofNullable(newValue);
+    }
+
+
+    /**
+     * Returns the initial state of the value being changed.
+     *
+     * @return the initial state of the value being changed.
+     */
+    public T getOldValue() {
+        return oldValue;
+    }
+
+
+    /**
+     * Returns the new value wrapped in an {@code Optional}. If the change is a
+     * deletion, the change will not contain a new value and
+     * {@code Optional.empty} will be returned instead.
+     *
+     * @return the new value wrapped in an {@code Optional}.
+     */
+    public Optional<T> getNewValue() {
+        return newValue;
+    }
+}

--- a/src/main/java/seedu/vms/model/Model.java
+++ b/src/main/java/seedu/vms/model/Model.java
@@ -51,6 +51,58 @@ public interface Model {
      */
     void setGuiSettings(GuiSettings guiSettings);
 
+
+    /*
+     * ========================================================================
+     * Keywords
+     * ========================================================================
+     */
+
+    void setKeywordManager(KeywordManager keywordManager);
+
+    /** Returns the {@code KeywordManager} the model is using. */
+    KeywordManager getKeywordManager();
+
+
+    /**
+     * Parses the specified user command.
+     *
+     * @param userCommand - the user command to parse.
+     * @return the {@code ParseResult} that results from the parsed user
+     *      command.
+     * @throws ParseException if the user command cannot be parsed.
+     */
+    ParseResult parseCommand(String userCommand) throws ParseException;
+
+    /**
+     * Adds the given keyword.
+     * {@code keyword} must not already exist in the keyword manager.
+     */
+    void addKeyword(Keyword keyword);
+
+    /**
+     * Deletes the given keyword.
+     * The keyword must exist in the keyword manager.
+     */
+    void deleteKeyword(int id);
+
+
+    /** Returns an unmodifiable view of the filtered keyword list */
+    ObservableMap<Integer, IdData<Keyword>> getFilteredKeywordList();
+
+    /**
+     * Updates the filter of the filtered keyword list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredKeywordList(Predicate<Keyword> predicate);
+
+
+    /*
+     * ========================================================================
+     * Patients
+     * ========================================================================
+     */
+
     /**
      * Replaces patient manager data with the data in {@code patientManager}.
      */
@@ -85,33 +137,50 @@ public interface Model {
     void setPatient(int id, Patient editedPatient);
 
     /**
-     * Replaces the given appointment {@code target} with {@code editedAppointment}.
-     * {@code target} must exist in the appointment manager.
-     * The appointment identity of {@code editedAppointment} must not be the same as
-     * another existing appointment in the appointment manager.
-     */
-    void setAppointment(int id, Appointment editedAppointment);
-
-    /** Returns an unmodifiable view of the filtered patient list */
-    ObservableMap<Integer, IdData<Patient>> getFilteredPatientList();
-
-    /** Returns an unmodifiable view of the filtered vaccination type map. */
-    ObservableMap<String, VaxType> getFilteredVaxTypeMap();
-
-    /** Returns an unmodifiable view of the filtered appointment map. */
-    ObservableMap<Integer, IdData<Appointment>> getFilteredAppointmentMap();
-
-    /**
      * Updates the filter of the filtered patient list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPatientList(Predicate<Patient> predicate);
 
-    /**
-     * Updates the filter of the filtered appointment list to filter by the given {@code predicate}.
-     * @throws NullPointerException if {@code predicate} is null.
+    /** Returns an unmodifiable view of the filtered patient list */
+    ObservableMap<Integer, IdData<Patient>> getFilteredPatientList();
+
+
+    /*
+     * ========================================================================
+     * Vaccination
+     * ========================================================================
      */
-    void updateFilteredAppointmentList(Predicate<Appointment> predicate);
+
+
+    void setVaxTypeManager(VaxTypeManager manager);
+
+
+    /** Returns the {@code VaxTypeManager} the model is using. */
+    VaxTypeManager getVaxTypeManager();
+
+    /** Performs the specified action of the {@code VaxTypeManager} that the model is using. */
+    VaxType performVaxTypeAction(VaxTypeAction action) throws IllegalValueException;
+
+    VaxType deleteVaxType(GroupName vaxName) throws IllegalValueException;
+
+
+    void setVaccinationFilters(Collection<Predicate<VaxType>> filters);
+
+    /** Returns an unmodifiable view of the filtered vaccination type map. */
+    ObservableMap<String, VaxType> getFilteredVaxTypeMap();
+
+
+    /*
+     * ========================================================================
+     * Appointment
+     * ========================================================================
+     */
+
+    void setAppointmentManager(AppointmentManager manager);
+
+    /** Returns the {@code AppointmentManager} the model is using. */
+    AppointmentManager getAppointmentManager();
 
     /**
      * Adds the given appointment.
@@ -125,27 +194,13 @@ public interface Model {
      */
     void deleteAppointment(int id);
 
-
-    /** Returns an unmodifiable view of the filtered keyword list */
-    ObservableMap<Integer, IdData<Keyword>> getFilteredKeywordList();
-
     /**
-     * Updates the filter of the filtered keyword list to filter by the given {@code predicate}.
-     * @throws NullPointerException if {@code predicate} is null.
+     * Replaces the given appointment {@code target} with {@code editedAppointment}.
+     * {@code target} must exist in the appointment manager.
+     * The appointment identity of {@code editedAppointment} must not be the same as
+     * another existing appointment in the appointment manager.
      */
-    void updateFilteredKeywordList(Predicate<Keyword> predicate);
-
-    /**
-     * Adds the given keyword.
-     * {@code keyword} must not already exist in the keyword manager.
-     */
-    void addKeyword(Keyword keyword);
-
-    /**
-     * Deletes the given keyword.
-     * The keyword must exist in the keyword manager.
-     */
-    void deleteKeyword(int id);
+    void setAppointment(int id, Appointment editedAppointment);
 
     /**
      * Marks the given appointment as completed.
@@ -159,39 +214,12 @@ public interface Model {
      */
     void unmarkAppointment(int id);
 
-
-    /** Returns the {@code VaxTypeManager} the model is using. */
-    VaxTypeManager getVaxTypeManager();
-
-    /** Returns the {@code AppointmentManager} the model is using. */
-    AppointmentManager getAppointmentManager();
-
-    /** Returns the {@code KeywordManager} the model is using. */
-    KeywordManager getKeywordManager();
-
-    /** Performs the specified action of the {@code VaxTypeManager} that the model is using. */
-    VaxType performVaxTypeAction(VaxTypeAction action) throws IllegalValueException;
-
-    VaxType deleteVaxType(GroupName vaxName) throws IllegalValueException;
-
-
     /**
-     * Parses the specified user command.
-     *
-     * @param userCommand - the user command to parse.
-     * @return the {@code ParseResult} that results from the parsed user
-     *      command.
-     * @throws ParseException if the user command cannot be parsed.
+     * Updates the filter of the filtered appointment list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
      */
-    ParseResult parseCommand(String userCommand) throws ParseException;
+    void updateFilteredAppointmentList(Predicate<Appointment> predicate);
 
-
-    void setVaxTypeManager(VaxTypeManager manager);
-
-    void setAppointmentManager(AppointmentManager manager);
-
-    void setKeywordManager(KeywordManager keywordManager);
-
-
-    void setVaccinationFilters(Collection<Predicate<VaxType>> filters);
+    /** Returns an unmodifiable view of the filtered appointment map. */
+    ObservableMap<Integer, IdData<Appointment>> getFilteredAppointmentMap();
 }

--- a/src/main/java/seedu/vms/model/Model.java
+++ b/src/main/java/seedu/vms/model/Model.java
@@ -1,10 +1,12 @@
 package seedu.vms.model;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableMap;
 import seedu.vms.commons.core.GuiSettings;
+import seedu.vms.commons.core.ValueChange;
 import seedu.vms.commons.exceptions.IllegalValueException;
 import seedu.vms.logic.parser.ParseResult;
 import seedu.vms.logic.parser.exceptions.ParseException;
@@ -222,4 +224,52 @@ public interface Model {
 
     /** Returns an unmodifiable view of the filtered appointment map. */
     ObservableMap<Integer, IdData<Appointment>> getFilteredAppointmentMap();
+
+
+    /**
+     * Validates if a patient change will result in appointments to be deleted.
+     * Returns a list of messages of the deletion change that will happen if
+     * the specified change were to occur. If no deletion change in appointment
+     * will happen, an empty {@code List} will be returned.
+     *
+     * @param change - the change in state of a patient to check.
+     * @return a list of messages describing the deletion change that will
+     *      occur if the specified change were to happen.
+     */
+    List<String> validatePatientChange(ValueChange<Patient> change);
+
+
+    /**
+     * Handles the specified change in state of a patient. Returns a list of
+     * messages describing the changes in appointment that has ocurred.
+     *
+     * @param change - the change to handle.
+     * @return a list of messages describing the changes in appointment that
+     *      has ocurred.
+     */
+    List<String> handlePatientChange(ValueChange<Patient> change);
+
+
+    /**
+     * Validates if a vaccination change will result in appointments to be
+     * deleted. Returns a list of messages of the deletion change that will
+     * happen if the specified change where to occur. If no deletion change in
+     * appointment will happen, an empty {@code List} will be returned.
+     *
+     * @param change - the change in state of vaccination to check.
+     * @return a list of messages describing the deletion change that will
+     *      occur if the specified change were to happen.
+     */
+    List<String> validateVaccinationChange(ValueChange<VaxType> change);
+
+
+    /**
+     * Handles the specified change in state of a vaccination. Returns a list
+     * of messages describing the changes in appointment that has ocurred.
+     *
+     * @param change - the change to handle.
+     * @return a list of messages describing the changes in appointment that
+     *      has ocurred.
+     */
+    List<String> handleVaccinationChange(ValueChange<VaxType> change);
 }

--- a/src/main/java/seedu/vms/model/ModelManager.java
+++ b/src/main/java/seedu/vms/model/ModelManager.java
@@ -4,12 +4,14 @@ import static java.util.Objects.requireNonNull;
 import static seedu.vms.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableMap;
 import seedu.vms.commons.core.GuiSettings;
 import seedu.vms.commons.core.LogsCenter;
+import seedu.vms.commons.core.ValueChange;
 import seedu.vms.commons.exceptions.IllegalValueException;
 import seedu.vms.logic.parser.ParseResult;
 import seedu.vms.logic.parser.VmsParser;
@@ -190,6 +192,42 @@ public class ModelManager implements Model {
     @Override
     public void setAppointmentManager(AppointmentManager manager) {
         appointmentManager.resetData(manager);
+    }
+
+
+    @Override
+    public List<String> validatePatientChange(ValueChange<Patient> change) {
+        //TODO: Implement this
+        // implementation should be in appointment manager instead of here
+        // as LogicManager is just a facade class.
+        return List.of();
+    }
+
+
+    @Override
+    public List<String> handlePatientChange(ValueChange<Patient> change) {
+        //TODO: Implement this
+        // implementation should be in appointment manager instead of here
+        // as LogicManager is just a facade class.
+        return List.of();
+    }
+
+
+    @Override
+    public List<String> validateVaccinationChange(ValueChange<VaxType> change) {
+        //TODO: Implement this
+        // implementation should be in appointment manager instead of here
+        // as LogicManager is just a facade class.
+        return List.of();
+    }
+
+
+    @Override
+    public List<String> handleVaccinationChange(ValueChange<VaxType> change) {
+        //TODO: Implement this
+        // implementation should be in appointment manager instead of here
+        // as LogicManager is just a facade class.
+        return List.of();
     }
 
     // =========== VaxTypeManager ==============================================================================

--- a/src/test/java/seedu/vms/logic/commands/patient/AddCommandTest.java
+++ b/src/test/java/seedu/vms/logic/commands/patient/AddCommandTest.java
@@ -9,12 +9,14 @@ import static seedu.vms.testutil.Assert.assertThrows;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableMap;
 import seedu.vms.commons.core.GuiSettings;
+import seedu.vms.commons.core.ValueChange;
 import seedu.vms.commons.exceptions.IllegalValueException;
 import seedu.vms.logic.CommandMessage;
 import seedu.vms.logic.parser.ParseResult;
@@ -259,6 +261,30 @@ public class AddCommandTest {
         public void setVaccinationFilters(Collection<Predicate<VaxType>> filters) {
             // TODO Auto-generated method stub
             throw new UnsupportedOperationException("Unimplemented method 'setVaccinationFilters'");
+        }
+
+        @Override
+        public List<String> validatePatientChange(ValueChange<Patient> change) {
+            // TODO Auto-generated method stub
+            throw new UnsupportedOperationException("Unimplemented method 'validatePatientChange'");
+        }
+
+        @Override
+        public List<String> handlePatientChange(ValueChange<Patient> change) {
+            // TODO Auto-generated method stub
+            throw new UnsupportedOperationException("Unimplemented method 'handlePatientChange'");
+        }
+
+        @Override
+        public List<String> validateVaccinationChange(ValueChange<VaxType> change) {
+            // TODO Auto-generated method stub
+            throw new UnsupportedOperationException("Unimplemented method 'validateVaccinationChange'");
+        }
+
+        @Override
+        public List<String> handleVaccinationChange(ValueChange<VaxType> change) {
+            // TODO Auto-generated method stub
+            throw new UnsupportedOperationException("Unimplemented method 'handleVaccinationChange'");
         }
     }
 

--- a/src/test/java/seedu/vms/logic/commands/vaccination/VaxTypeModelStub.java
+++ b/src/test/java/seedu/vms/logic/commands/vaccination/VaxTypeModelStub.java
@@ -1,10 +1,12 @@
 package seedu.vms.logic.commands.vaccination;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableMap;
 import seedu.vms.commons.core.GuiSettings;
+import seedu.vms.commons.core.ValueChange;
 import seedu.vms.commons.exceptions.IllegalValueException;
 import seedu.vms.logic.parser.ParseResult;
 import seedu.vms.logic.parser.exceptions.ParseException;
@@ -210,6 +212,30 @@ public class VaxTypeModelStub implements Model {
     @Override
     public void setVaccinationFilters(Collection<Predicate<VaxType>> filters) {
         filteredMapView.setFilters(filters);
+    }
+
+    @Override
+    public List<String> validatePatientChange(ValueChange<Patient> change) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'validatePatientChange'");
+    }
+
+    @Override
+    public List<String> handlePatientChange(ValueChange<Patient> change) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'handlePatientChange'");
+    }
+
+    @Override
+    public List<String> validateVaccinationChange(ValueChange<VaxType> change) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'validateVaccinationChange'");
+    }
+
+    @Override
+    public List<String> handleVaccinationChange(ValueChange<VaxType> change) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'handleVaccinationChange'");
     }
 
 }


### PR DESCRIPTION
Create the skeletal methods to be implemented:

* `validatePatientChange(ValueChange)` - given a `ValueChange` of `Patient` return a list of messages describing what appointments will be deleted if that change were to happen. Patient `edit` (probs not) and `delete` command will use this list to display a warning message. @nusE0726844 
* `handlePatientChange(ValueChange)` - given a `ValueChange` of `Patient` return a list of messages describing all changes that has happen in appointment. The command that resulted in this change will use the list to display a message to the user. @nusE0726844 
* `validateVaccinationChange(ValueChange)` - similar to `validatePatientChange(ValueChange)`. @nusE0726844 
* `handleVaccinationChange(ValueChange)` - similar to `handlePatientChange(ValueChange)` except that patient manager will be involved as well (I think only renaming operations). @francisyzy @nusE0726844 

Cascading delete is required as `NullPointerException` may be thrown if either the patient or vaccination no longer exists in the system on appointment edit commands. It is okay if the patient contains vaccinations that are not in the system as that can be ignored but the patient and vaccination of the appointment cannot.

### Issues addressed

* Closes #128 