### PR TITLE
Append functionalities for edition of list like attributes

### DIFF
--- a/src/main/java/seedu/vms/logic/commands/patient/EditCommand.java
+++ b/src/main/java/seedu/vms/logic/commands/patient/EditCommand.java
@@ -69,7 +69,7 @@ public class EditCommand extends Command {
      */
     public EditCommand(Index index, EditPatientDescriptor editPatientDescriptor) {
         // TODO: this should be removed
-        this(index, editPatientDescriptor, false);
+        this(index, editPatientDescriptor, true);
     }
 
     /**

--- a/src/main/java/seedu/vms/logic/commands/patient/EditCommand.java
+++ b/src/main/java/seedu/vms/logic/commands/patient/EditCommand.java
@@ -116,8 +116,8 @@ public class EditCommand extends Command {
         Dob updatedDob = editPatientDescriptor.getDob().orElse(patientToEdit.getDob());
         BloodType updatedBloodType = editPatientDescriptor.getBloodType().orElse(patientToEdit.getBloodType());
 
-        Set<GroupName> updatedAllergies = patientToEdit.getAllergy();
-        Set<GroupName> updatedVaccines = patientToEdit.getVaccine();
+        HashSet<GroupName> updatedAllergies = new HashSet<>(patientToEdit.getAllergy());
+        HashSet<GroupName> updatedVaccines = new HashSet<>(patientToEdit.getVaccine());
 
         if (isSet) {
             editPatientDescriptor.getAllergies().ifPresent(allergies -> {

--- a/src/main/java/seedu/vms/logic/commands/vaccination/EditVaxTypeCommand.java
+++ b/src/main/java/seedu/vms/logic/commands/vaccination/EditVaxTypeCommand.java
@@ -21,7 +21,7 @@ public class EditVaxTypeCommand extends Command {
 
     private final Retriever<String, VaxType> retriever;
     private final VaxTypeBuilder builder;
-    private final boolean isAppend;
+    private final boolean isSet;
 
 
     /**
@@ -30,10 +30,10 @@ public class EditVaxTypeCommand extends Command {
      * @param retriever - the retriever to retrieve the vaccination to edit.
      * @param builder - the builder to use to update the vaccination type.
      */
-    public EditVaxTypeCommand(Retriever<String, VaxType> retriever, VaxTypeBuilder builder, boolean isAppend) {
+    public EditVaxTypeCommand(Retriever<String, VaxType> retriever, VaxTypeBuilder builder, boolean isSet) {
         this.retriever = Objects.requireNonNull(retriever);
         this.builder = Objects.requireNonNull(builder);
-        this.isAppend = isAppend;
+        this.isSet = isSet;
     }
 
 
@@ -44,7 +44,7 @@ public class EditVaxTypeCommand extends Command {
 
         try {
             VaxType toUpdate = model.getVaccination(retriever);
-            VaxType newValue = builder.update(toUpdate, isAppend);
+            VaxType newValue = builder.update(toUpdate, isSet);
             ValueChange<VaxType> change = model.editVaccination(toUpdate.getName(), newValue);
             return new CommandMessage(String.format(MESSAGE_SUCCESS, change.toString()));
         } catch (IllegalValueException ive) {

--- a/src/main/java/seedu/vms/logic/commands/vaccination/EditVaxTypeCommand.java
+++ b/src/main/java/seedu/vms/logic/commands/vaccination/EditVaxTypeCommand.java
@@ -21,6 +21,7 @@ public class EditVaxTypeCommand extends Command {
 
     private final Retriever<String, VaxType> retriever;
     private final VaxTypeBuilder builder;
+    private final boolean isAppend;
 
 
     /**
@@ -29,9 +30,10 @@ public class EditVaxTypeCommand extends Command {
      * @param retriever - the retriever to retrieve the vaccination to edit.
      * @param builder - the builder to use to update the vaccination type.
      */
-    public EditVaxTypeCommand(Retriever<String, VaxType> retriever, VaxTypeBuilder builder) {
+    public EditVaxTypeCommand(Retriever<String, VaxType> retriever, VaxTypeBuilder builder, boolean isAppend) {
         this.retriever = Objects.requireNonNull(retriever);
         this.builder = Objects.requireNonNull(builder);
+        this.isAppend = isAppend;
     }
 
 
@@ -42,7 +44,7 @@ public class EditVaxTypeCommand extends Command {
 
         try {
             VaxType toUpdate = model.getVaccination(retriever);
-            VaxType newValue = builder.update(toUpdate);
+            VaxType newValue = builder.update(toUpdate, isAppend);
             ValueChange<VaxType> change = model.editVaccination(toUpdate.getName(), newValue);
             return new CommandMessage(String.format(MESSAGE_SUCCESS, change.toString()));
         } catch (IllegalValueException ive) {

--- a/src/main/java/seedu/vms/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/vms/logic/parser/CliSyntax.java
@@ -8,11 +8,12 @@ public class CliSyntax {
 
     /*
      * ========================================================================
-     * Vaccination
+     * Misc
      * ========================================================================
      */
 
     public static final Prefix PREFIX_FORCE = new Prefix("force");
+    public static final Prefix PREFIX_SET = new Prefix("set");
 
     /* Prefix definitions */
     public static final Prefix PREFIX_NAME = new Prefix("n");

--- a/src/main/java/seedu/vms/logic/parser/patient/EditCommandParser.java
+++ b/src/main/java/seedu/vms/logic/parser/patient/EditCommandParser.java
@@ -18,6 +18,7 @@ import seedu.vms.commons.core.index.Index;
 import seedu.vms.logic.commands.patient.EditCommand;
 import seedu.vms.logic.commands.patient.EditCommand.EditPatientDescriptor;
 import seedu.vms.logic.parser.ArgumentMultimap;
+import seedu.vms.logic.parser.CliSyntax;
 import seedu.vms.logic.parser.CommandParser;
 import seedu.vms.logic.parser.ParserUtil;
 import seedu.vms.logic.parser.exceptions.ParseException;
@@ -73,7 +74,11 @@ public class EditCommandParser implements CommandParser {
             throw new ParseException(errMessage.get());
         }
 
-        return new EditCommand(index, editPatientDescriptor);
+        boolean isSet = argsMap.getValue(CliSyntax.PREFIX_SET)
+                .map(input -> ParserUtil.parseBoolean(input))
+                .orElse(false);
+
+        return new EditCommand(index, editPatientDescriptor, isSet);
     }
 
     /**

--- a/src/main/java/seedu/vms/logic/parser/vaccination/EditVaxTypeParser.java
+++ b/src/main/java/seedu/vms/logic/parser/vaccination/EditVaxTypeParser.java
@@ -3,6 +3,7 @@ package seedu.vms.logic.parser.vaccination;
 import seedu.vms.commons.core.Retriever;
 import seedu.vms.logic.commands.vaccination.EditVaxTypeCommand;
 import seedu.vms.logic.parser.ArgumentMultimap;
+import seedu.vms.logic.parser.CliSyntax;
 import seedu.vms.logic.parser.ParserUtil;
 import seedu.vms.logic.parser.exceptions.ParseException;
 import seedu.vms.model.vaccination.VaxType;
@@ -20,6 +21,9 @@ public class EditVaxTypeParser extends VaxTypeBuilderParser {
     public EditVaxTypeCommand parse(ArgumentMultimap argsMap) throws ParseException {
         Retriever<String, VaxType> retriever = ParserUtil.parseVaxRetriever(argsMap.getPreamble());
         VaxTypeBuilder builder = parseBuilder(argsMap);
-        return new EditVaxTypeCommand(retriever, builder);
+        boolean isSet = argsMap.getValue(CliSyntax.PREFIX_SET)
+                .map(input -> ParserUtil.parseBoolean(input))
+                .orElse(false);
+        return new EditVaxTypeCommand(retriever, builder, isSet);
     }
 }

--- a/src/test/java/seedu/vms/testutil/SampleVaxTypeData.java
+++ b/src/test/java/seedu/vms/testutil/SampleVaxTypeData.java
@@ -42,7 +42,8 @@ public class SampleVaxTypeData {
     public static final String CMD_GROUPS_REAL = CliSyntax.DELIMITER + CliSyntax.PREFIX_VAX_GROUPS.getPrefix() + " "
             + "DOSE 1,"
             + "Pfizer,"
-            + "Vaccination";
+            + "Vaccination"
+            + " --set true";
     public static final String CMD_MIN_AGE_REAL = CliSyntax.DELIMITER + CliSyntax.PREFIX_MIN_AGE.getPrefix() + " 5";
     public static final String CMD_MAX_AGE_REAL = "";
     public static final String CMD_INGREDIENTS_REAL = CliSyntax.DELIMITER
@@ -54,10 +55,11 @@ public class SampleVaxTypeData {
             + "Sucrose,"
             + "Phosphate,"
             + "Tromethamine,"
-            + "Tromethamine hydrochloride";
+            + "Tromethamine hydrochloride"
+            + " --set true";
     public static final String CMD_HISTORY_REQS_REAL = CliSyntax.DELIMITER
             + CliSyntax.PREFIX_HISTORY_REQ.getPrefix()
-            + " none::DOSE 1";
+            + " none::DOSE 1 --set true";
 
     public static final GroupName NAME_1 = new GroupName("UNCHI");
     public static final HashSet<GroupName> GROUPS_1 = new HashSet<>(List.of(
@@ -78,11 +80,11 @@ public class SampleVaxTypeData {
             HISTORY_REQS_1);
     public static final String CMD_NAME_1 = "UNCHI";
     public static final String CMD_GROUPS_1 = CliSyntax.DELIMITER + CliSyntax.PREFIX_VAX_GROUPS.getPrefix()
-            + " UNCHI";
+            + " UNCHI --set true";
     public static final String CMD_MIN_AGE_1 = CliSyntax.DELIMITER + CliSyntax.PREFIX_MIN_AGE.getPrefix() + " 35";
     public static final String CMD_MAX_AGE_1 = CliSyntax.DELIMITER + CliSyntax.PREFIX_MAX_AGE.getPrefix() + " 45";
     public static final String CMD_INGREDIENTS_1 = CliSyntax.DELIMITER + CliSyntax.PREFIX_INGREDIENTS.getPrefix()
-            + " UNCHI";
+            + " UNCHI --set true";
     public static final String CMD_HISTORY_REQS_1 = CliSyntax.DELIMITER + CliSyntax.PREFIX_HISTORY_REQ.getPrefix()
-            + " none::UNCHI";
+            + " none::UNCHI --set true";
 }


### PR DESCRIPTION
By default edit command for `patient` and `vaccination` replaces list like attributes such as `Allergies` or `Ingredients`.

Now the default will be append to those lists. Set all is still supported but an additional flag `--set true` will have to be added.

Example

1.
```
p edit 1 --v abc
```
![image](https://user-images.githubusercontent.com/100074448/228434567-7760dc81-0be2-43a5-8a28-e79ac8230334.png)

2.
```
p edit 1 --v efg --set true
```
![image](https://user-images.githubusercontent.com/100074448/228434726-60ce6028-2df5-4dd2-8eb3-8d3715e20af5.png)

### Issues addressed

* Closes #206 