### PR TITLE
Enhance messages

### DIFF
--- a/src/main/java/seedu/vms/MainApp.java
+++ b/src/main/java/seedu/vms/MainApp.java
@@ -148,14 +148,6 @@ public class MainApp extends Application {
             logger.warning("Default user preference will be used due to: " + e.getMessage());
             initializedPrefs = new UserPrefs();
         }
-
-        // Update prefs file in case it was missing to begin with or there are new/unused fields
-        try {
-            storage.saveUserPrefs(initializedPrefs);
-        } catch (IOException e) {
-            logger.warning("Failed to save config file : " + StringUtil.getDetails(e));
-        }
-
         return initializedPrefs;
     }
 
@@ -164,7 +156,7 @@ public class MainApp extends Application {
         logger.info("Starting PatientManager " + MainApp.VERSION);
         ui.start(primaryStage);
         startRefreshLoop();
-        logic.loadManagers();
+        logic.loadManagers(ui::showErrorDialogAndShutdown);
     }
 
 

--- a/src/main/java/seedu/vms/commons/core/Messages.java
+++ b/src/main/java/seedu/vms/commons/core/Messages.java
@@ -12,10 +12,9 @@ public class Messages {
             + "invalid";
     public static final String MESSAGE_PATIENTS_LISTED_OVERVIEW = "%1$d patients listed!";
     public static final String MESSAGE_APPOINTMENTS_LISTED_OVERVIEW = "%1$d appointments listed!";
+    public static final String MESSAGE_VACCINATION_LISTED_OVERVIEW = "%d vaccinations listed!";
     public static final String MESSAGE_INVALID_KEYWORD_DISPLAYED_INDEX = "The keyword index provided is invalid";
 
-    public static final String MESSAGE_VACCINATION_LISTED_OVERVIEW = "Filter(s) applied %d vaccinations listed";
-    public static final String MESSAGE_VACCINATION_FILTER_CLEAR = "Filter(s) cleared %d vaccinations listed";
 
     public static final String FORMAT_UNEXPECTED_APPOINTMENT_CHANGE = "Unexpected change detected!\n"
             + "The following appointments will become invalid if the change were to happen:%s";

--- a/src/main/java/seedu/vms/commons/util/StringUtil.java
+++ b/src/main/java/seedu/vms/commons/util/StringUtil.java
@@ -163,4 +163,34 @@ public class StringUtil {
         return message.substring(0, message.length() - 1);
     }
 
+
+    /**
+     * Wraps the text to the specified length.
+     */
+    public static String wrapText(String text, int wrapAt) {
+        String[] lines = text.split("[\n\r]");
+        StringBuilder builder = new StringBuilder();
+        for (String line : lines) {
+            builder.append(wrapLine(line, wrapAt));
+        }
+        return builder.toString().strip();
+    }
+
+
+    /**
+     * Wraps the line to the specified length. An additional new line will
+     * always be present at the end.
+     */
+    public static String wrapLine(String line, int wrapAt) {
+        int cur = 0;
+        StringBuilder builder = new StringBuilder();
+        while (cur < line.length()) {
+            int nextCur = Math.min(cur + wrapAt, line.length());
+            builder.append(line.substring(cur, nextCur));
+            builder.append("\n");
+            cur = nextCur;
+        }
+        return builder.toString();
+    }
+
 }

--- a/src/main/java/seedu/vms/logic/Logic.java
+++ b/src/main/java/seedu/vms/logic/Logic.java
@@ -1,6 +1,7 @@
 package seedu.vms.logic;
 
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import javafx.beans.property.ObjectProperty;
@@ -34,7 +35,7 @@ public interface Logic {
     void setOnExecutionCompletion(Consumer<List<CommandMessage>> onExecutionComplete);
 
 
-    void loadManagers();
+    void loadManagers(BiConsumer<String, String> beyondDeathErrHandler);
 
 
     /**

--- a/src/main/java/seedu/vms/logic/LogicManager.java
+++ b/src/main/java/seedu/vms/logic/LogicManager.java
@@ -1,10 +1,12 @@
 package seedu.vms.logic;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 
@@ -193,12 +195,18 @@ public class LogicManager implements Logic {
 
 
     @Override
-    public void loadManagers() {
-        new Thread(this::performLoadSequence).start();
+    public void loadManagers(BiConsumer<String, String> beyondDeathErrHandler) {
+        new Thread(() -> performLoadSequence(beyondDeathErrHandler)).start();
     }
 
 
-    private void performLoadSequence() {
+    private void performLoadSequence(BiConsumer<String, String> beyondDeathErrHandler) {
+        if (Path.of("data").toFile().isFile()) {
+            beyondDeathErrHandler.accept(
+                    "[data] already exists and is not a directory",
+                    "Close the application and remove [data] file before restarting.");
+        }
+
         ReadOnlyPatientManager patientManager = new PatientManager();
         try {
             patientManager = storage.readPatientManager();

--- a/src/main/java/seedu/vms/logic/commands/vaccination/DetailVaxTypeCommand.java
+++ b/src/main/java/seedu/vms/logic/commands/vaccination/DetailVaxTypeCommand.java
@@ -33,6 +33,6 @@ public class DetailVaxTypeCommand extends Command {
             throw new CommandException(ive.getMessage());
         }
         model.setDetailedVaxType(vaxType);
-        return new CommandMessage("Detailing vaccination");
+        return new CommandMessage(String.format("Detailing vaccination: %s", vaxType.getName()));
     }
 }

--- a/src/main/java/seedu/vms/logic/commands/vaccination/ListVaxTypeCommand.java
+++ b/src/main/java/seedu/vms/logic/commands/vaccination/ListVaxTypeCommand.java
@@ -16,6 +16,6 @@ public class ListVaxTypeCommand extends Command {
     public CommandMessage execute(Model model) throws CommandException {
         model.setVaccinationFilters(List.of());
         int numListed = model.getFilteredVaxTypeMap().size();
-        return new CommandMessage(String.format(Messages.MESSAGE_VACCINATION_FILTER_CLEAR, numListed));
+        return new CommandMessage(String.format(Messages.MESSAGE_VACCINATION_LISTED_OVERVIEW, numListed));
     }
 }

--- a/src/main/java/seedu/vms/logic/parser/FeatureParser.java
+++ b/src/main/java/seedu/vms/logic/parser/FeatureParser.java
@@ -51,11 +51,15 @@ public abstract class FeatureParser {
             for (String arg : entry.getValue()) {
                 if (prefix.equals(new Prefix("")) && arg.isBlank()) {
                     continue;
+                } else if (prefix.equals(new Prefix(""))) {
+                    builder.append(String.format("\n[PREAMBLE] %s",
+                            arg));
+                } else {
+                    builder.append(String.format("\n%s%s %s",
+                            CliSyntax.DELIMITER,
+                            prefix.toString(),
+                            arg));
                 }
-                builder.append(String.format("\n%s%s %s",
-                        CliSyntax.DELIMITER,
-                        prefix.toString(),
-                        arg));
             }
         }
 

--- a/src/main/java/seedu/vms/logic/parser/appointment/AddCommandParser.java
+++ b/src/main/java/seedu/vms/logic/parser/appointment/AddCommandParser.java
@@ -32,8 +32,7 @@ public class AddCommandParser implements CommandParser {
      */
     @Override
     public AddCommand parse(ArgumentMultimap argsMap) throws ParseException {
-        if (!arePrefixesPresent(argsMap, PREFIX_PATIENT, PREFIX_STARTTIME, PREFIX_ENDTIME, PREFIX_VACCINATION)
-                || !argsMap.getPreamble().isEmpty()) {
+        if (!arePrefixesPresent(argsMap, PREFIX_PATIENT, PREFIX_STARTTIME, PREFIX_ENDTIME, PREFIX_VACCINATION)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 

--- a/src/main/java/seedu/vms/logic/parser/patient/AddCommandParser.java
+++ b/src/main/java/seedu/vms/logic/parser/patient/AddCommandParser.java
@@ -38,8 +38,7 @@ public class AddCommandParser implements CommandParser {
      */
     @Override
     public AddCommand parse(ArgumentMultimap argsMap) throws ParseException {
-        if (!arePrefixesPresent(argsMap, PREFIX_NAME, PREFIX_PHONE, PREFIX_DOB, PREFIX_BLOODTYPE)
-                || !argsMap.getPreamble().isEmpty()) {
+        if (!arePrefixesPresent(argsMap, PREFIX_NAME, PREFIX_PHONE, PREFIX_DOB, PREFIX_BLOODTYPE)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 

--- a/src/main/java/seedu/vms/ui/ResultMessageBox.java
+++ b/src/main/java/seedu/vms/ui/ResultMessageBox.java
@@ -6,6 +6,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.TextArea;
 import javafx.scene.layout.Region;
 import javafx.scene.text.Text;
+import seedu.vms.commons.util.StringUtil;
 import seedu.vms.logic.CommandMessage;
 
 
@@ -39,6 +40,7 @@ public class ResultMessageBox extends UiPart<Region> {
 
 
     private void setMessage(String message) {
+        String displayMessage = StringUtil.wrapText(message, 180);
         // listener block adapted from https://stackoverflow.com/a/25643696 and modified
         messageArea.textProperty().addListener((ob, oldText, newText) -> {
             Platform.runLater(() -> {
@@ -50,7 +52,7 @@ public class ResultMessageBox extends UiPart<Region> {
                 messageArea.setPrefHeight(height);
             });
         });
-        messageArea.setText(message);
+        messageArea.setText(displayMessage);
     }
 
 

--- a/src/main/java/seedu/vms/ui/Ui.java
+++ b/src/main/java/seedu/vms/ui/Ui.java
@@ -10,4 +10,6 @@ public interface Ui extends Refreshable {
     /** Starts the UI (and the App).  */
     void start(Stage primaryStage);
 
+    /** Show error dialog and close app. */
+    void showErrorDialogAndShutdown(String mainMessage, String additionalMessage);
 }

--- a/src/main/java/seedu/vms/ui/UiManager.java
+++ b/src/main/java/seedu/vms/ui/UiManager.java
@@ -90,4 +90,14 @@ public class UiManager implements Ui {
         System.exit(1);
     }
 
+
+    @Override
+    public void showErrorDialogAndShutdown(String mainMessage, String additionalMessage) {
+        Platform.runLater(() -> {
+            showAlertDialogAndWait(Alert.AlertType.ERROR, "ERROR", mainMessage, additionalMessage);
+            Platform.exit();
+            System.exit(1);
+        });
+    }
+
 }

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -119,7 +119,7 @@
 }
 
 .result-message-warning-color {
-  -fx-text-fill: #bc5050;
+  -fx-text-fill: #bcb750;
 }
 
 .result-message-info-color {

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -119,7 +119,7 @@
 }
 
 .result-message-warning-color {
-  -fx-text-fill: #bcb750;
+  -fx-text-fill: #bc5050;
 }
 
 .result-message-info-color {
@@ -189,4 +189,31 @@
 
 .label.tag.tag-color-red {
   -fx-background-color: #901515;
+}
+
+/* ===== Dialog pane ======================================================= */
+
+.dialog-pane {
+  -fx-background-color: #1d1d1d;
+}
+
+.dialog-pane > *.button-bar > *.container {
+  -fx-background-color: #1d1d1d;
+}
+
+.dialog-pane > *.label.content {
+  -fx-font-size: 14px;
+  -fx-font-weight: bold;
+  -fx-text-fill: white;
+}
+
+.dialog-pane:header *.header-panel {
+  -fx-background-color: derive(#1d1d1d, 25%);
+}
+
+.dialog-pane:header *.header-panel *.label {
+  -fx-font-size: 18px;
+  -fx-font-style: italic;
+  -fx-fill: white;
+  -fx-text-fill: white;
 }

--- a/src/main/resources/view/RequirementBox.fxml
+++ b/src/main/resources/view/RequirementBox.fxml
@@ -4,10 +4,9 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 
-
-<HBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" spacing="5.0" xmlns="http://javafx.com/javafx/null" xmlns:fx="http://javafx.com/fxml/1">
+<HBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefWidth="390.0" spacing="5.0" xmlns="http://javafx.com/javafx/null" xmlns:fx="http://javafx.com/fxml/1">
    <children>
       <Label fx:id="indexLabel" prefWidth="20.0" />
-      <VBox fx:id="tagBox" />
+      <VBox fx:id="tagBox" maxWidth="-Infinity" minWidth="-Infinity" prefWidth="365.0" HBox.hgrow="SOMETIMES" />
    </children>
 </HBox>

--- a/src/main/resources/view/VaxTypeCard.fxml
+++ b/src/main/resources/view/VaxTypeCard.fxml
@@ -30,7 +30,7 @@
       <VBox spacing="5.0" GridPane.columnSpan="2147483647" GridPane.rowIndex="4">
          <children>
             <Label styleClass="card-attribute-title-label" text="History requirement(s)" wrapText="true" />
-            <VBox fx:id="historyBox" spacing="5.0" />
+            <VBox fx:id="historyBox" maxWidth="-Infinity" minWidth="-Infinity" prefWidth="390.0" spacing="5.0" />
          </children>
       </VBox>
    </children>

--- a/src/test/java/seedu/vms/logic/parser/patient/AddCommandParserTest.java
+++ b/src/test/java/seedu/vms/logic/parser/patient/AddCommandParserTest.java
@@ -139,11 +139,6 @@ public class AddCommandParserTest {
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + DOB_DESC_BOB + INVALID_BLOODTYPE_DESC,
                 Name.MESSAGE_CONSTRAINTS);
-
-        // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + DOB_DESC_BOB
-                + BLOODTYPE_DESC_BOB + ALLERGY_DESC_SEAFOOD + ALLERGY_DESC_GLUTEN,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
     @Test
     public void execute_groupOverLimit_exceptionThrown() {

--- a/src/test/java/seedu/vms/logic/parser/patient/AddCommandParserTest.java
+++ b/src/test/java/seedu/vms/logic/parser/patient/AddCommandParserTest.java
@@ -16,7 +16,6 @@ import static seedu.vms.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.vms.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.vms.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.vms.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
-import static seedu.vms.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.vms.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.vms.logic.commands.CommandTestUtil.VALID_ALLERGY_GLUTEN;
 import static seedu.vms.logic.commands.CommandTestUtil.VALID_ALLERGY_SEAFOOD;


### PR DESCRIPTION
### Changes

* Handle exception when `data` exists but it is a file instead of a directory
  * Case where the contents of `data` are directories instead of files are not handled. (I think this can be considered extreme behaviour as for someone to make that happen is almost impossible to be coincidental)
* Improve start up warning messages to include line and column number of error
* Patient and Appointment add commands now allows but ignores preamble (for unused argument warning message)
* Fix issues where vaccination detail card requirements get cut off
* Add wrapping to command messages so that scroll bar does not show up (but still try to keep message lines below 180 characters)