### PR TITLE
Add check for patients with multiple appointments

### DIFF
--- a/src/main/java/seedu/vms/logic/commands/appointment/UnmarkCommand.java
+++ b/src/main/java/seedu/vms/logic/commands/appointment/UnmarkCommand.java
@@ -44,6 +44,17 @@ public class UnmarkCommand extends Command {
         }
 
         Appointment appointmentToUnmark = appointmentList.get(targetIndex.getZeroBased()).getValue();
+
+        Index patientId = appointmentToUnmark.getPatient();
+        for (Map.Entry<Integer, IdData<Appointment>> entry : model.getAppointmentManager().getMapView().entrySet()) {
+            Appointment appointment = entry.getValue().getValue();
+            if (appointment.getPatient().equals(patientId)
+                    && !appointment.getStatus()) {
+                throw new CommandException(String.format("Patient #%04d has active appointments",
+                        patientId.getOneBased()));
+            }
+        }
+
         model.unmarkAppointment(targetIndex.getZeroBased());
         return new CommandMessage(String.format(MESSAGE_UNMARK_APPOINTMENT_SUCCESS, appointmentToUnmark));
     }


### PR DESCRIPTION
* Add checks to ensure that unmarking an appointment will not result in a patient having multiple active appointments.
* Add check to ensure that a patient does not have multiple active appointmetns on start up.