### PR TITLE
Refactor VaxTypeManager to follow appointment and patient

### DIFF
--- a/src/main/java/seedu/vms/commons/core/Retriever.java
+++ b/src/main/java/seedu/vms/commons/core/Retriever.java
@@ -59,7 +59,8 @@ public abstract class Retriever<K, V> {
         try {
             return list.get(index);
         } catch (IndexOutOfBoundsException oobEx) {
-            throw new IllegalValueException(oobEx.getMessage());
+            throw new IllegalValueException(String.format("Index %d out of bounds for length %d",
+                    index + 1, list.size()));
         }
     }
 

--- a/src/main/java/seedu/vms/model/Model.java
+++ b/src/main/java/seedu/vms/model/Model.java
@@ -20,6 +20,7 @@ import seedu.vms.model.keyword.Keyword;
 import seedu.vms.model.keyword.KeywordManager;
 import seedu.vms.model.patient.Patient;
 import seedu.vms.model.patient.ReadOnlyPatientManager;
+import seedu.vms.model.vaccination.ReadOnlyVaxTypeManage;
 import seedu.vms.model.vaccination.VaxType;
 import seedu.vms.model.vaccination.VaxTypeManager;
 
@@ -160,7 +161,7 @@ public interface Model {
 
 
     /** Returns the {@code VaxTypeManager} the model is using. */
-    VaxTypeManager getVaxTypeManager();
+    ReadOnlyVaxTypeManage getVaxTypeManager();
 
     ValueChange<VaxType> addVaccination(VaxType vaxType) throws IllegalValueException;
 

--- a/src/main/java/seedu/vms/model/vaccination/ReadOnlyVaxTypeManage.java
+++ b/src/main/java/seedu/vms/model/vaccination/ReadOnlyVaxTypeManage.java
@@ -1,0 +1,57 @@
+package seedu.vms.model.vaccination;
+
+import java.util.Optional;
+
+import javafx.collections.ObservableMap;
+
+
+/**
+ * Represents a vax type manager that supports only read functionalities.
+ */
+public interface ReadOnlyVaxTypeManage {
+    /**
+     * Returns the {@code VaxType} mapped to the specified name wrapped in an
+     * {@code Optional}. If there are no mappings to the specified name,
+     * {@code Optional.empty} is returned instead.
+     *
+     * @param name - the name of the {@code VaxType} to get.
+     * @return the {@code VaxType} mapped to the specified name wrapped in an
+     *      {@code Optional}.
+     */
+    public Optional<VaxType> get(String name);
+
+
+    /**
+     * Returns if the manager contains a mapping to the specified name.
+     *
+     * @param name - the name of the {@code VaxType} to check.
+     * @return {@code true} if the manager contains a mapping to the
+     *      specified name and {@code false} otherwise.
+     */
+    public boolean contains(String name);
+
+
+    /**
+     * Returns the number of mappings the manager has.
+     *
+     * @return the number of mappings the manager has.
+     */
+    public int size();
+
+
+    /**
+     * Returns if this manager is empty.
+     *
+     * @returns {@code true} if the manager is empty and {@code false}
+     *      otherwise.
+     */
+    public boolean isEmpty();
+
+
+    /**
+     * Returns an unmodifiable map view of this manager.
+     *
+     * @return an unmodifiable map view of this manager.
+     */
+    public ObservableMap<String, VaxType> asUnmodifiableObservableMap();
+}

--- a/src/main/java/seedu/vms/model/vaccination/VaxTypeManager.java
+++ b/src/main/java/seedu/vms/model/vaccination/VaxTypeManager.java
@@ -15,7 +15,7 @@ import seedu.vms.commons.exceptions.LimitExceededException;
  *
  * <p>The uniqueness of {@code VaxType} names are maintained.
  */
-public class VaxTypeManager {
+public class VaxTypeManager implements ReadOnlyVaxTypeManage {
     public static final int DEFAULT_LIMIT = 30;
 
     private static final String ERROR_FORMAT_DUPLICATE_VACCINATION = "Vaccination %s already exist";
@@ -101,20 +101,6 @@ public class VaxTypeManager {
 
 
     /**
-     * Returns the {@code VaxType} mapped to the specified name, wrapped in an
-     * {@code Optional}. If there are no mappings to the specified name,
-     * {@code Optional.empty} is returned instead.
-     *
-     * @param name - the name of the {@code VaxType} to retrieve.
-     * @return the {@code VaxType} mapped to the specified name, wrapped in an
-     *      {@code Optional}.
-     */
-    public Optional<VaxType> get(String name) {
-        return Optional.ofNullable(typeMap.get(name));
-    }
-
-
-    /**
      * Removes the {@code VaxType} with the specified name. The {@code VaxType}
      * removed is returned and wrapped in an {@code Optional}. If there are no
      * mappings, to the specified name, nothing is done and
@@ -128,41 +114,31 @@ public class VaxTypeManager {
     }
 
 
-    /**
-     * Returns if this storage map contains a mapping to the specified name.
-     *
-     * @return {@code true} if there is a {@code VaxType} mapped to the
-     *      specified name and {@code false} otherwise.
-     */
+    @Override
+    public Optional<VaxType> get(String name) {
+        return Optional.ofNullable(typeMap.get(name));
+    }
+
+
+    @Override
     public boolean contains(String name) {
         return typeMap.containsKey(name);
     }
 
 
-    /**
-     * Returns the number of {@code VaxType} stored within this manager.
-     */
+    @Override
     public int size() {
         return typeMap.size();
     }
 
 
-    /**
-     * Returns if the manager is empty.
-     *
-     * @return {@code true} if the manager contains zero {@code VaxType} and
-     *      {@code false} otherwise.
-     */
+    @Override
     public boolean isEmpty() {
         return typeMap.isEmpty();
     }
 
 
-    /**
-     * Returns an unmodifiable map view of this storage.
-     *
-     * @return an unmodifiable map view ot this storage.
-     */
+    @Override
     public ObservableMap<String, VaxType> asUnmodifiableObservableMap() {
         return unmodifiableTypeMap;
     }

--- a/src/main/java/seedu/vms/storage/StorageManager.java
+++ b/src/main/java/seedu/vms/storage/StorageManager.java
@@ -9,6 +9,7 @@ import seedu.vms.model.UserPrefs;
 import seedu.vms.model.appointment.AppointmentManager;
 import seedu.vms.model.keyword.KeywordManager;
 import seedu.vms.model.patient.ReadOnlyPatientManager;
+import seedu.vms.model.vaccination.ReadOnlyVaxTypeManage;
 import seedu.vms.model.vaccination.VaxTypeManager;
 import seedu.vms.storage.appointment.AppointmentStorage;
 import seedu.vms.storage.keyword.KeywordStorage;
@@ -81,7 +82,7 @@ public class StorageManager implements Storage {
     }
 
     @Override
-    public void saveVaxTypes(VaxTypeManager manager) throws IOException {
+    public void saveVaxTypes(ReadOnlyVaxTypeManage manager) throws IOException {
         vaxTypeStorage.saveVaxTypes(manager);
     }
 

--- a/src/main/java/seedu/vms/storage/vaccination/JsonVaxTypeStorage.java
+++ b/src/main/java/seedu/vms/storage/vaccination/JsonVaxTypeStorage.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 
 import seedu.vms.commons.exceptions.IllegalValueException;
 import seedu.vms.commons.util.FileUtil;
+import seedu.vms.model.vaccination.ReadOnlyVaxTypeManage;
 import seedu.vms.model.vaccination.VaxTypeManager;
 
 
@@ -37,7 +38,7 @@ public class JsonVaxTypeStorage implements VaxTypeStorage {
 
 
     @Override
-    public void saveVaxTypes(VaxTypeManager manager) throws IOException {
+    public void saveVaxTypes(ReadOnlyVaxTypeManage manager) throws IOException {
         FileUtil.createIfMissing(USER_VAX_FILE_PATH);
         VaxTypeLoader.fromModelType(manager).write(USER_VAX_FILE_PATH);
     }

--- a/src/main/java/seedu/vms/storage/vaccination/VaxTypeLoader.java
+++ b/src/main/java/seedu/vms/storage/vaccination/VaxTypeLoader.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.vms.commons.exceptions.IllegalValueException;
 import seedu.vms.commons.util.JsonUtil;
+import seedu.vms.model.vaccination.ReadOnlyVaxTypeManage;
 import seedu.vms.model.vaccination.VaxType;
 import seedu.vms.model.vaccination.VaxTypeManager;
 
@@ -31,7 +32,7 @@ public class VaxTypeLoader {
     /**
      * Converts the specified {@code VaxTypeManager} to a {@code VaxTypeLoader}.
      */
-    public static VaxTypeLoader fromModelType(VaxTypeManager manager) {
+    public static VaxTypeLoader fromModelType(ReadOnlyVaxTypeManage manager) {
         List<JsonAdaptedVaxType> types = manager
                 .asUnmodifiableObservableMap()
                 .values()

--- a/src/main/java/seedu/vms/storage/vaccination/VaxTypeStorage.java
+++ b/src/main/java/seedu/vms/storage/vaccination/VaxTypeStorage.java
@@ -2,6 +2,7 @@ package seedu.vms.storage.vaccination;
 
 import java.io.IOException;
 
+import seedu.vms.model.vaccination.ReadOnlyVaxTypeManage;
 import seedu.vms.model.vaccination.VaxTypeManager;
 
 
@@ -31,5 +32,5 @@ public interface VaxTypeStorage {
      *
      * @throws IOException if an I/O error occurs.
      */
-    public void saveVaxTypes(VaxTypeManager manager) throws IOException;
+    public void saveVaxTypes(ReadOnlyVaxTypeManage manager) throws IOException;
 }


### PR DESCRIPTION
To use a `ReadOnlyVaxTypeManager`.

Fixes misleading index message as well.

Closes #320 