### PR TITLE
Fix id not increasing

### DIFF
--- a/src/main/java/seedu/vms/model/IdDataMap.java
+++ b/src/main/java/seedu/vms/model/IdDataMap.java
@@ -103,10 +103,15 @@ public class IdDataMap<T> {
      */
     public ValueChange<IdData<T>> remove(int id) {
         IdData<T> removedData = internalMap.remove(id);
-        if (internalMap.isEmpty()) {
-            nextId = 0;
-        }
         return new ValueChange<>(removedData, null);
+    }
+
+
+    /**
+     * Resets the ID count.
+     */
+    public void resetIdCount() {
+        nextId = 0;
     }
 
 

--- a/src/main/java/seedu/vms/model/IdDataMap.java
+++ b/src/main/java/seedu/vms/model/IdDataMap.java
@@ -58,6 +58,7 @@ public class IdDataMap<T> {
     public IdData<T> add(T value) throws LimitExceededException {
         Objects.requireNonNull(value);
         IdData<T> data = new IdData<>(getNextId(), value);
+        nextId++;
         return add(data);
     }
 
@@ -74,7 +75,7 @@ public class IdDataMap<T> {
             throw new LimitExceededException(String.format(Messages.FORMAT_LIMIT_EX, limit));
         }
         internalMap.put(data.getId(), data);
-        nextId = Math.max(nextId, data.getId());
+        nextId = Math.max(nextId, data.getId() + 1);
         return data;
     }
 
@@ -171,9 +172,10 @@ public class IdDataMap<T> {
         if (internalMap.size() >= limit) {
             throw new LimitExceededException(String.format(Messages.FORMAT_LIMIT_EX, limit));
         }
-        while (contains(nextId)) {
-            nextId++;
-            if (!isValidId(nextId)) {
+        while (contains(nextId) || !isValidId(nextId)) {
+            if (isValidId(nextId)) {
+                nextId++;
+            } else {
                 nextId = 0;
             }
         }

--- a/src/main/java/seedu/vms/model/IdDataMap.java
+++ b/src/main/java/seedu/vms/model/IdDataMap.java
@@ -89,10 +89,6 @@ public class IdDataMap<T> {
      * @throws NoSuchElementException if the ID is not present.
      */
     public ValueChange<IdData<T>> set(int id, T value) {
-        if (!internalMap.containsKey(id)) {
-            // TODO: this exception is unhandled by utilising methods.
-            throw new NoSuchElementException(String.format("ID [%d] not found", id));
-        }
         IdData<T> newValue = new IdData<>(id, value);
         IdData<T> oldValue = internalMap.put(id, newValue);
         return new ValueChange<>(oldValue, newValue);

--- a/src/main/java/seedu/vms/model/IdDataMap.java
+++ b/src/main/java/seedu/vms/model/IdDataMap.java
@@ -128,7 +128,6 @@ public class IdDataMap<T> {
      * @param datas - the collection of data to set to.
      */
     public void setDatas(Collection<IdData<T>> datas) {
-        // TODO: Check for duplicate ID
         internalMap.clear();
         nextId = STARTING_INDEX;
         for (IdData<T> data : datas) {

--- a/src/main/java/seedu/vms/model/Model.java
+++ b/src/main/java/seedu/vms/model/Model.java
@@ -116,6 +116,12 @@ public interface Model {
      */
     void deletePatient(int id, boolean isForce) throws UnexpectedChangeException;
 
+
+    /**
+     * Resets patient manager's ID count.
+     */
+    void resetPatientIds();
+
     /**
      * Adds the given patient.
      * {@code patient} must not already exist in the patient manager.

--- a/src/main/java/seedu/vms/model/ModelManager.java
+++ b/src/main/java/seedu/vms/model/ModelManager.java
@@ -172,6 +172,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void resetPatientIds() {
+        patientManager.resetIdCount();
+    }
+
+    @Override
     public void addPatient(Patient patient) {
         IdData<Patient> newValue = patientManager.add(patient);
         updateFilteredPatientList(PREDICATE_SHOW_ALL_PATIENTS);

--- a/src/main/java/seedu/vms/model/StorageModel.java
+++ b/src/main/java/seedu/vms/model/StorageModel.java
@@ -139,6 +139,14 @@ public abstract class StorageModel<T> implements ReadOnlyStorageModel<T> {
     }
 
 
+    /**
+     * Resets the ID count.
+     */
+    public void resetIdCount() {
+        dataMap.resetIdCount();
+    }
+
+
     // ===== ReadOnlyStorageModel overrides
 
 

--- a/src/test/java/seedu/vms/logic/commands/patient/AddCommandTest.java
+++ b/src/test/java/seedu/vms/logic/commands/patient/AddCommandTest.java
@@ -333,6 +333,12 @@ public class AddCommandTest {
             // TODO Auto-generated method stub
             throw new UnsupportedOperationException("Unimplemented method 'deleteVaccination'");
         }
+
+        @Override
+        public void resetPatientIds() {
+            // TODO Auto-generated method stub
+            throw new UnsupportedOperationException("Unimplemented method 'resetPatientIds'");
+        }
     }
 
     /**

--- a/src/test/java/seedu/vms/logic/commands/vaccination/VaxTypeModelStub.java
+++ b/src/test/java/seedu/vms/logic/commands/vaccination/VaxTypeModelStub.java
@@ -286,4 +286,10 @@ public class VaxTypeModelStub implements Model {
         throw new UnsupportedOperationException("Unimplemented method 'deletePatient'");
     }
 
+    @Override
+    public void resetPatientIds() {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'resetPatientIds'");
+    }
+
 }

--- a/src/test/java/seedu/vms/model/IdDataMapTest.java
+++ b/src/test/java/seedu/vms/model/IdDataMapTest.java
@@ -90,6 +90,29 @@ public class IdDataMapTest {
 
 
     @Test
+    public void addAndDeleteTest() {
+        /*
+         * Test ensures that ID increases on an add operation after the recently added
+         * element was deleted immediately
+         */
+
+        // element to ensure that map is not empty
+        // first so 0
+        idMap.add(0);
+
+        // second so 1
+        int idDel = idMap.add(1).getId();
+        idMap.remove(idDel);
+
+        // third so 2
+        int idNext = idMap.add(2).getId();
+
+        assertEquals(1, idDel);
+        assertEquals(2, idNext);
+    }
+
+
+    @Test
     public void setValues_withinLimit_valuesAdded() {
         ArrayList<Integer> values = new ArrayList<>();
         for (int i = 0; i < TESTING_LIMIT; i++) {

--- a/src/test/java/seedu/vms/model/IdDataMapTest.java
+++ b/src/test/java/seedu/vms/model/IdDataMapTest.java
@@ -96,19 +96,15 @@ public class IdDataMapTest {
          * element was deleted immediately
          */
 
-        // element to ensure that map is not empty
         // first so 0
-        idMap.add(0);
-
-        // second so 1
-        int idDel = idMap.add(1).getId();
+        int idDel = idMap.add(0).getId();
         idMap.remove(idDel);
 
-        // third so 2
+        // second so 1
         int idNext = idMap.add(2).getId();
 
-        assertEquals(1, idDel);
-        assertEquals(2, idNext);
+        assertEquals(0, idDel);
+        assertEquals(1, idNext);
     }
 
 

--- a/src/test/java/seedu/vms/model/IdDataMapTest.java
+++ b/src/test/java/seedu/vms/model/IdDataMapTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.NoSuchElementException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -144,8 +143,6 @@ public class IdDataMapTest {
         idMap.add(initial);
         idMap.set(0, change);
         assertEquals(change, idMap.get(0).getValue());
-
-        assertThrows(NoSuchElementException.class, () -> idMap.set(1, change));
     }
 
 


### PR DESCRIPTION
Fixes #353 

Also fixes issue where delete command will reset ID count when ID related managers are emptied. The fixed behaviour is the behavour before feature freeze. Bug was introduced from clear command fix.