### PR TITLE
Start up bug fix

### DIFF
--- a/src/main/java/seedu/vms/model/IdDataMap.java
+++ b/src/main/java/seedu/vms/model/IdDataMap.java
@@ -71,8 +71,12 @@ public class IdDataMap<T> {
      */
     public IdData<T> add(IdData<T> data) throws LimitExceededException {
         Objects.requireNonNull(data);
-        if (!isValidId(data.getId())) {
+        if (!isWithinLimit(data.getId())) {
+            // if ID exceeds limit
             throw new LimitExceededException(String.format(Messages.FORMAT_LIMIT_EX, limit));
+        } else if (!isValidId(data.getId())) {
+            // all other cases of invalid ID
+            throw new IllegalArgumentException("Invalid ID");
         }
         internalMap.put(data.getId(), data);
         nextId = Math.max(nextId, data.getId() + 1);
@@ -187,7 +191,14 @@ public class IdDataMap<T> {
     }
 
 
+    /** Returns if the given ID is valid. */
     private boolean isValidId(int id) {
         return 0 <= id && id < limit;
+    }
+
+
+    /** Returns if the given ID is within the set limit. */
+    private boolean isWithinLimit(int id) {
+        return id < limit;
     }
 }

--- a/src/main/java/seedu/vms/storage/appointment/JsonAdaptedAppointment.java
+++ b/src/main/java/seedu/vms/storage/appointment/JsonAdaptedAppointment.java
@@ -85,11 +85,7 @@ public class JsonAdaptedAppointment {
         }
         builder = builder.setStatus(isCompleted);
 
-        try {
-            return builder.create(new AppointmentManager());
-        } catch (IllegalArgumentException illArgEx) {
-            throw new IllegalValueException(illArgEx.getMessage());
-        }
+        return builder.create(new AppointmentManager());
     }
 
 

--- a/src/main/java/seedu/vms/storage/appointment/JsonAdaptedAppointment.java
+++ b/src/main/java/seedu/vms/storage/appointment/JsonAdaptedAppointment.java
@@ -60,6 +60,8 @@ public class JsonAdaptedAppointment {
 
         if (patientId == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "PATIENT ID"));
+        } else if (patientId < 1) {
+            throw new IllegalValueException("Invalid PATIENT ID");
         }
         AppointmentBuilder builder = AppointmentBuilder.of(Index.fromOneBased(patientId));
 
@@ -83,7 +85,11 @@ public class JsonAdaptedAppointment {
         }
         builder = builder.setStatus(isCompleted);
 
-        return builder.create(new AppointmentManager());
+        try {
+            return builder.create(new AppointmentManager());
+        } catch (IllegalArgumentException illArgEx) {
+            throw new IllegalValueException(illArgEx.getMessage());
+        }
     }
 
 

--- a/src/main/java/seedu/vms/storage/appointment/JsonSerializableAppointmentManager.java
+++ b/src/main/java/seedu/vms/storage/appointment/JsonSerializableAppointmentManager.java
@@ -69,8 +69,9 @@ class JsonSerializableAppointmentManager {
             try {
                 appointmentManager.add(appointmentData);
             } catch (LimitExceededException limitEx) {
-                // TODO: better message
                 throw new IllegalValueException("ID limit reached");
+            } catch (IllegalArgumentException illArgEx) {
+                throw new IllegalValueException(illArgEx.getMessage());
             }
         }
         return appointmentManager;

--- a/src/main/java/seedu/vms/storage/patient/JsonSerializablePatientManager.java
+++ b/src/main/java/seedu/vms/storage/patient/JsonSerializablePatientManager.java
@@ -61,8 +61,9 @@ public class JsonSerializablePatientManager {
             try {
                 patientManager.add(patientData);
             } catch (LimitExceededException limitEx) {
-                // TODO: better message
                 throw new IllegalValueException("ID limit reached");
+            } catch (IllegalArgumentException illArgEx) {
+                throw new IllegalValueException(illArgEx.getMessage());
             }
         }
         return patientManager;

--- a/src/test/java/seedu/vms/model/IdDataMapTest.java
+++ b/src/test/java/seedu/vms/model/IdDataMapTest.java
@@ -61,8 +61,6 @@ public class IdDataMapTest {
     @Test
     public void add_dataOverLimit_exceptionThrown() {
         assertThrows(LimitExceededException.class,
-                () -> idMap.add(new IdData<>(true, -1, -1)));
-        assertThrows(LimitExceededException.class,
                 () -> idMap.add(new IdData<>(true, TESTING_LIMIT, TESTING_LIMIT)));
     }
 
@@ -137,20 +135,6 @@ public class IdDataMapTest {
         idMap.setDatas(datas);
         for (int i = 0; i < TESTING_LIMIT; i++) {
             assertEquals(i, idMap.get(i).getValue());
-        }
-    }
-
-
-    @Test
-    public void setDatas_overLimit_exceptionThrown() {
-        List<Integer> idValues = List.of(-1, TESTING_LIMIT);
-        for (Integer id : idValues) {
-            for (int i = 0; i < TESTING_LIMIT; i++) {
-                ArrayList<IdData<Integer>> datas = formRandDataList();
-                datas.remove(i);
-                datas.add(i, new IdData<>(true, id, id));
-                assertThrows(LimitExceededException.class, () -> idMap.setDatas(datas));
-            }
         }
     }
 


### PR DESCRIPTION
### Fix misleading load up message

Before, "ID limit reached" shows when the ID is invalid (eg. -1). This mislead the user to think that they cannot add anymore data. Fix produces a generic message "Invalid ID" without giving any more details in such cases.

### Fix appointment dying when in valid patient ID in file

IndexOutOfBound shown which is an incorrect and misleading message.